### PR TITLE
iOS 13 fixes. Revert to accessory for compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Existing users of my original fork or gw-wiscon's be sure to update the "platfor
 
 # Changelog
 
-* Verison 0.7 By default, changes accessory from a Switch to new TV accessory in iOS 12.2+. Input labels can customized with `inputs` in the config. To use the legacy Switch service (i.e. if you haven't upgraded to 12.2+ yet), add `"switch_service": true` to your receiver in config. An optional Dimmer service for separate volume control is available, useful for non-iPhone control and more advanced automations (it appears as a dimmable light bulb). To use, add `"volume_dimmer": true` to your receiver in config.
+* Verison 0.7 iOS 12.2+ is now required. This is now a Platform, theoretically supporting multiple receivers. Each receiver is a TV accessory (which is why iOS 12.2+ is required). Input labels can customized with `inputs` in the config. An optional Dimmer service for separate volume control is available, useful for non-iPhone control and more advanced automations (it appears as a dimmable light bulb). To disable the volume dimmer, add `"volume_dimmer": false` to your receiver in config.
 * Version 0.6 includes support for zone2. Adds a new config parameter called "zone" and use "zone2". Thanks for the contrib mbbeaubi.
 * Version 0.5.x includes support for input-selector. Available inputs are dynamically pulled from the eiscp-commands.json file. Note: Not all inputs may work with your receiver.
 * Version 0.4.x includes support for volume, mute, and has options for setting default_input.
@@ -39,30 +39,37 @@ For Troubleshooting look in the homebridge-onkyo/node_modules/eiscp/examples dir
 
 Example accessory config (needs to be added to the homebridge config.json):
  ```
-"accessories": [{
-        "accessory": "Onkyo",
-		"model": "TX-NR609",
-		"ip_address": "10.0.0.46",
-		"poll_status_interval": "30",
-		"name": "Receiver",
-		"inputs": {
-			"dvd": "Blu-ray",
-			"video2": "Switch",
-			"video3": "Wii U",
-			"video6": "Apple TV",
-			"video4": "AUX",
-			"cd": "TV/CD"
-		},
-		"volume_dimmer": false,
-		"switch_service": false,
-		"filter_inputs": true
+"platforms": [{
+        "platform": "Onkyo",
+        "receivers": [
+            {
+                "model": "TX-NR609",
+                "ip_address": "10.0.0.46",
+                "poll_status_interval": "3000",
+                "name": "Receiver",
+                "inputs": {
+                    "dvd": "Blu-ray",
+                    "video2": "Switch",
+                    "video3": "Wii U",
+                    "video6": "Apple TV",
+                    "video4": "AUX",
+                    "cd": "TV/CD"
+                },
+                "volume_dimmer": false,
+                "switch_service": false,
+                "filter_inputs": true
+            }
+        ]
     }]
  ```
 ### Config Explanation:
 
 Field           			| Description
 ----------------------------|------------
-**accessory**   			| (required) Must always be "Onkyo".
+**platform**   			| (required) Must always be "Onkyo".
+**receivers**               | (required) List of receiver accessories to create. Must contain at least 1.
+Receiver Attributes         |
+----------------------------|------------
 **name**					| (required) The name you want to use for control of the Onkyo accessories.
 **ip_address**  			| (required) The internal ip address of your Onkyo.
 **model**					| (required) Must be a valid model listed in node_modules/eiscp/eiscp-commands.json file. If your model is not listed, you can use the TX-NR609 if your model supports the Integra Serial Communication Protocol (ISCP).
@@ -74,5 +81,4 @@ Field           			| Description
 **zone**              		| (optional) Defaults to main. Optionally control zone2 where supported.
 **inputs**					| (optional) List of inputs you want populated for the TV service and what you want them to be labeled. Inputs not listed are omitted.
 **filter_inputs**                   | (optional) Boolean value. Setting this to `true` limits inputs displayed in HomeKit to those you provide in `inputs`. If `false` or not defined, all inputs supported by `model` will be displayed.
-**volume_dimmer**					| (optional) Boolean value. Setting this to `true` enables additional Dimmer accessory for separate volume control.
-**switch_service**					| (optional) Boolean value. Setting this to `true` enables uses legacy Switch service instead of the new TV service.
+**volume_dimmer**					| (optional) Boolean value. Setting this to `false` disables additional Dimmer accessory for separate volume control.

--- a/README.md
+++ b/README.md
@@ -39,28 +39,6 @@ For Troubleshooting look in the homebridge-onkyo/node_modules/eiscp/examples dir
 
 Example platform config (needs to be added to the homebridge config.json):
  ```
-<<<<<<< HEAD
-"accessories": [
-	{
-		"accessory": "Onkyo-tv",
-		"name": "Stereo",
-		"ip_address": "10.0.1.23",
-		"model" : "TX-NR609",
-		"poll_status_interval": "900",
-		"default_input": "net",
-		"default_volume": "10",
-		"max_volume": "35",
-		"map_volume_100": true,
-		"zone" : "zone2",
-		"inputs": {
-				"dvd": "Blu-ray",
-				"video6": "Apple TV",
-				"video4": "AUX",
-				"cd": "TV/CD"
-			}
-	}
-]
-=======
 "platforms": [{
         "platform": "Onkyo",
         "name": "Onkyo",
@@ -85,7 +63,6 @@ Example platform config (needs to be added to the homebridge config.json):
             }
         ]
     }]
->>>>>>> platform
  ```
 ### Config Explanation:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Existing users of my original fork or gw-wiscon's be sure to update the "platfor
 
 # Changelog
 
-* Verison 0.7 converts from Accessory to Platform, in theory allowing control of multiple receivers. Refer to the sample config section for a usage example. By default changes accessory from a Switch to new TV accessory in iOS 12.2. To use the legacy Switch service (i.e. if you haven't upgraded to 12.2 yet), add `"switch_service": true` to your receiver in config. Adds optional Dimmer service for separate volume control. To use, add `"volume_dimmer": true` to your receiver in config.
+* Verison 0.7 By default, changes accessory from a Switch to new TV accessory in iOS 12.2+. Input labels can customized with `inputs` in the config. To use the legacy Switch service (i.e. if you haven't upgraded to 12.2+ yet), add `"switch_service": true` to your receiver in config. An optional Dimmer service for separate volume control is available, useful for non-iPhone control and more advanced automations (it appears as a dimmable light bulb). To use, add `"volume_dimmer": true` to your receiver in config.
 * Version 0.6 includes support for zone2. Adds a new config parameter called "zone" and use "zone2". Thanks for the contrib mbbeaubi.
 * Version 0.5.x includes support for input-selector. Available inputs are dynamically pulled from the eiscp-commands.json file. Note: Not all inputs may work with your receiver.
 * Version 0.4.x includes support for volume, mute, and has options for setting default_input.
@@ -22,7 +22,7 @@ For Alexa Control of Volume, Mute, Input - (if using the Alexa plugin) - create 
 
 # To Do
 
-~Complete re-write to convert to a Platform.~ This will allow for auto discovery of all receivers (if more than one exist), and other flexibility.
+Complete re-write to convert to a Platform. This will allow for auto discovery of all receivers (if more than one exist), and other flexibility.
 Adding Speaker A/B on/off control
 Others...
 
@@ -37,40 +37,32 @@ For Troubleshooting look in the homebridge-onkyo/node_modules/eiscp/examples dir
 
 # Configuration
 
-Example platform config (needs to be added to the homebridge config.json):
+Example accessory config (needs to be added to the homebridge config.json):
  ```
-"platforms": [{
-        "platform": "Onkyo",
-        "name": "Onkyo",
-        "receivers": [
-            {
-                "model": "TX-NR609",
-                "ip_address": "10.0.1.6",
-                "poll_status_interval": "3000",
-                "max_volume": "55",
-                "map_volume_100": true,
-                "name": "Receiver",
-                "inputs": {
-                    "dvd": "Blu-ray",
-                    "video2": "Switch",
-                    "video3": "Xbox",
-                    "video6": "Apple TV",
-                    "video4": "AUX",
-                    "cd": "TV/CD"
-                },
-                "volume_dimmer": false,
-				"switch_service": false
-            }
-        ]
+"accessories": [{
+        "accessory": "Onkyo",
+		"model": "TX-NR609",
+		"ip_address": "10.0.0.46",
+		"poll_status_interval": "30",
+		"name": "Receiver",
+		"inputs": {
+			"dvd": "Blu-ray",
+			"video2": "Switch",
+			"video3": "Wii U",
+			"video6": "Apple TV",
+			"video4": "AUX",
+			"cd": "TV/CD"
+		},
+		"volume_dimmer": false,
+		"switch_service": false,
+		"filter_inputs": true
     }]
  ```
 ### Config Explanation:
 
 Field           			| Description
 ----------------------------|------------
-**platform**   			| (required) Must always be "Onkyo".
-**name**        			| (required) Must always be "Onkyo".
-**receivers**				| (requierd) A list of receivers to control.
+**accessory**   			| (required) Must always be "Onkyo".
 **name**					| (required) The name you want to use for control of the Onkyo accessories.
 **ip_address**  			| (required) The internal ip address of your Onkyo.
 **model**					| (required) Must be a valid model listed in node_modules/eiscp/eiscp-commands.json file. If your model is not listed, you can use the TX-NR609 if your model supports the Integra Serial Communication Protocol (ISCP).
@@ -81,5 +73,6 @@ Field           			| Description
 **map_volume_100**  		| (optional) Will remap the volume percentages that appear in the Home app so that the configured max_volume will appear as 100% in the Home app. For example, if the max_volume is 30, then setting the volume slider to 50% would set the receiver's actual volume to 15. Adjusting the stereo volume knob to 35 will appear as 100% in the Home app. This option could confuse some users to it defaults to off false, but it does give the user finer volume control especially when sliding volume up and down in the Home app. Defaults to False.
 **zone**              		| (optional) Defaults to main. Optionally control zone2 where supported.
 **inputs**					| (optional) List of inputs you want populated for the TV service and what you want them to be labeled. Inputs not listed are omitted.
+**filter_inputs**                   | (optional) Boolean value. Setting this to `true` limits inputs displayed in HomeKit to those you provide in `inputs`. If `false` or not defined, all inputs supported by `model` will be displayed.
 **volume_dimmer**					| (optional) Boolean value. Setting this to `true` enables additional Dimmer accessory for separate volume control.
 **switch_service**					| (optional) Boolean value. Setting this to `true` enables uses legacy Switch service instead of the new TV service.

--- a/index.js
+++ b/index.js
@@ -392,9 +392,21 @@ class OnkyoAccessory {
 						}
 					// If the AVR has just been turned on, apply the Input default
 						this.log.debug("Attempting to set the default input selector to "+this.defaultInput);
-						if (powerOn && this.defaultInput) {
-							this.log.info("Setting default input selector to "+this.defaultInput);
-							this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["input"] + "="+this.defaultInput, function(error, response) {
+
+						// Handle defaultInput being either a custom label or manufacturer label
+						var label = this.defaultInput;
+						this.configured_inputs.forEach((input, i) => {
+							if (input["displayName"] == this.defaultInput) {
+								RxInputs["Inputs"].forEach((x, y) => {
+									if (x["code"] == input["subtype"]) {
+										label = x["label"];
+									}
+								})
+							}
+						})
+						if (powerOn && label) {
+							this.log.info("Setting default input selector to "+label);
+							this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["input"] + "="+label, function(error, response) {
 								if (error) {
 									this.log.error( "Error while setting default input: %s", error);
 								}

--- a/index.js
+++ b/index.js
@@ -76,14 +76,19 @@ class OnkyoAccessory {
 		this.mapVolume100 = config['map_volume_100'] || false;
 
 		this.buttons = {
-			[Characteristic.RemoteKey.ARROW_UP]: 'up',
-			[Characteristic.RemoteKey.ARROW_DOWN]: 'down',
-			[Characteristic.RemoteKey.ARROW_LEFT]: 'left',
-			[Characteristic.RemoteKey.ARROW_RIGHT]: 'right',
-			[Characteristic.RemoteKey.SELECT]: 'enter',
-			[Characteristic.RemoteKey.BACK]: 'exit',
-			[Characteristic.RemoteKey.EXIT]: 'exit',
-			[Characteristic.RemoteKey.INFORMATION]: 'home',
+			[Characteristic.RemoteKey.REWIND]: 'rew',
+			[Characteristic.RemoteKey.FAST_FORWARD]: 'ff',
+			[Characteristic.RemoteKey.NEXT_TRACK]: 'skip-f',
+			[Characteristic.RemoteKey.PREVIOUS_TRACK]: 'skip-r',
+			[Characteristic.RemoteKey.ARROW_UP]: 'up', // 4
+			[Characteristic.RemoteKey.ARROW_DOWN]: 'down', // 5
+			[Characteristic.RemoteKey.ARROW_LEFT]: 'left', // 6
+			[Characteristic.RemoteKey.ARROW_RIGHT]: 'right', // 7
+			[Characteristic.RemoteKey.SELECT]: 'enter', // 8
+			[Characteristic.RemoteKey.BACK]: 'exit', // 9
+			[Characteristic.RemoteKey.EXIT]: 'exit', // 10
+			[Characteristic.RemoteKey.PLAY_PAUSE]: 'play', // 11
+			[Characteristic.RemoteKey.INFORMATION]: 'home', // 15
 		};
 
 		this.state = false;
@@ -138,7 +143,7 @@ class OnkyoAccessory {
 		} else {
 			this.tvService = this.createTvService();
 			this.enabledServices.push(this.tvService);
-			// this.createTvSpeakerService(television);
+			this.createTvSpeakerService(this.tvService);
 			this.enabledServices.push(...this.addSources(this.tvService));
 		}
 	}
@@ -745,6 +750,7 @@ class OnkyoAccessory {
 	}
 	
 	remoteKeyPress(button, callback) {
+		this.log.info(button);
 		//do the callback immediately, to free homekit
 		//have the event later on execute changes
 		callback(null, button);
@@ -753,7 +759,7 @@ class OnkyoAccessory {
 			this.log.debug("remoteKeyPress - INPUT: pressing key %s", press);
 			this.eiscp.command(this.zone + "." + "setup=" + press, function( error, data) {
 				if (error) {
-					this.i_state = 1;
+					// this.i_state = 1;
 					this.log.error( "remoteKeyPress - INPUT: ERROR pressing button %s", press);
 				}
 			}.bind(this) );

--- a/index.js
+++ b/index.js
@@ -5,738 +5,753 @@ var RxTypes, RxInputs;
 var pollingtoevent = require('polling-to-event');
 var round = require( 'math-round' );
 var accessories = [];
-var package = require('./package.json')
+var info = require('./package.json')
 
-module.exports = function(homebridge)
+module.exports = (homebridge) =>
 {
   Service = homebridge.hap.Service;
   Characteristic = homebridge.hap.Characteristic;
   Accessory = homebridge.platformAcessory;
   UUIDGen = homebridge.hap.uuid;
   RxTypes = require('./RxTypes.js')(homebridge);
+//   OnkyoPlatform.init(homebridge);
   homebridge.registerPlatform("homebridge-onkyo", "Onkyo", OnkyoPlatform);
 }
 
-function OnkyoPlatform (log, config, api) {
-	var platform = this;
-	this.api = api;
-	this.config = config;
-	this.log = log;
-	this.receivers = this.config['receivers']
-}
+class OnkyoPlatform {
+	constructor(log, config, api) {
+		// this.homebridge = homebridge
+		// this.UUID = UUIDGen;
+		// var platform = this;
+		this.api = api;
+		this.config = config;
+		this.log = log;
+		this.receivers = this.config['receivers'];
+		this.receiverAccessories = [];
 
-OnkyoPlatform.prototype.accessories = function(callback) {
-	var self = this;
-	this.numberReceivers = this.receivers.length;
-	this.log.debug("Creating %s receivers...", this.numberReceivers);
-
-	this.receivers.forEach(function(receiver) {
-		var accessory = new OnkyoAccessory(self, receiver);
-		accessories.push(accessory);
-	})
-
-	callback(accessories);
-}
-
-
-function OnkyoAccessory (platform, receiver)
-{	
-	this.platform = platform;
-	this.log = platform.log;
-	var that = this;
-
-	this.eiscp = require('eiscp');
-	this.setAttempt = 0;
-	this.enabledServices = [];
-
-	config = receiver;
-	this.name = config["name"];
-	this.ip_address	= config["ip_address"];
-	this.model = config["model"];
-	this.zone = config["zone"] || "main";
-	this.inputs = config["inputs"];
-	this.volume_dimmer = config["volume_dimmer"] || false;
-	this.switch_service = config["switch_service"] || false;
-
-
-	this.cmdMap = new Array();
-	this.cmdMap["main"] = new Array();
-	this.cmdMap["main"]["power"] = "system-power";
-	this.cmdMap["main"]["volume"] = "master-volume";
-	this.cmdMap["main"]["muting"] = "audio-muting";
-	this.cmdMap["main"]["input"] = "input-selector";
-	this.cmdMap["zone2"] = new Array();
-	this.cmdMap["zone2"]["power"] = "power";
-	this.cmdMap["zone2"]["volume"] = "volume";
-	this.cmdMap["zone2"]["muting"] = "muting";
-	this.cmdMap["zone2"]["input"] = "selector";
-
-	this.poll_status_interval = config["poll_status_interval"] || "0";
-	this.defaultInput = config["default_input"];
-	this.defaultVolume = config['default_volume'];
-	this.maxVolume = config['max_volume'] || 30;
-	this.mapVolume100 = config['map_volume_100'] || false;
-
-	this.buttons = {
-		[Characteristic.RemoteKey.ARROW_UP]: 'up',
-		[Characteristic.RemoteKey.ARROW_DOWN]: 'down',
-		[Characteristic.RemoteKey.ARROW_LEFT]: 'left',
-		[Characteristic.RemoteKey.ARROW_RIGHT]: 'right',
-		[Characteristic.RemoteKey.SELECT]: 'enter',
-		[Characteristic.RemoteKey.BACK]: 'exit',
-		[Characteristic.RemoteKey.EXIT]: 'exit',
-		[Characteristic.RemoteKey.INFORMATION]: 'home',
-	};
-
-	this.state = false;
-	this.m_state = false;
-	this.v_state = 0;
-	this.i_state = 1;
-	this.interval = parseInt( this.poll_status_interval);
-	this.avrManufacturer = "Onkyo";
-	this.avrSerial = this.ip_address;
-
-	// this.eiscp.discover(function(err,result){
-	// 	if(err) {
-	// 		that.log.debug("Onkyo - ERROR - No RX found. Result: %s", result);
-    //    } else {
-	// 		that.log.debug("Onkyo - Found these receivers on the local network. Connecting to first...");
-	// 		that.log.debug(result);
-	// 		that.avrSerial = result[0].mac;
-    //    }
-	// });
-
-	this.switchHandling = "check";
-	if (this.interval > 10 && this.interval < 100000) {
-		this.switchHandling = "poll";
+		this.createAccessories(this, this.receivers);
 	}
 
-	this.eiscp.on('debug', this.eventDebug.bind(this));
-	this.eiscp.on('error', this.eventError.bind(this));
-	this.eiscp.on('connect', this.eventConnect.bind(this));
-  	this.eiscp.on('close', this.eventClose.bind(this));
-	this.eiscp.on(this.cmdMap[this.zone]["power"], this.eventSystemPower.bind(this));
-	this.eiscp.on(this.cmdMap[this.zone]["volume"], this.eventVolume.bind(this));
-	this.eiscp.on(this.cmdMap[this.zone]["muting"], this.eventAudioMuting.bind(this));
-	this.eiscp.on(this.cmdMap[this.zone]["input"], this.eventInput.bind(this));
+	// static init(homebridgeRef) {
+	// 	this.homebridge = homebridgeRef
+	// }
 
-	this.eiscp.connect(
-		{host: this.ip_address, reconnect: true, model: this.model}
-	);
-
-// Create the RxInput object for later use.
-	var eiscpData = require('./node_modules/eiscp/eiscp-commands.json');
-	eiscpData = eiscpData.commands.main.SLI.values;
-	var newobj = '{ "Inputs" : [';
-	for (var exkey in eiscpData) {
-			var hold = eiscpData[exkey].name.toString();
-			if (hold.includes(',')) {
-					hold = hold.substring(0,hold.indexOf(','));
-			}
-      if (exkey.includes('“') || exkey.includes('“')) {
-          exkey = exkey.replace(/\“/g, "");
-          exkey = exkey.replace(/\”/g, "");
-      }
-			newobj = newobj + '{ "code":"'+exkey+'" , "label":"'+hold+'" },';
+	createAccessories(platform, receivers) {
+		platform.numberReceivers = platform.receivers.length;
+		platform.log.debug("Creating %s receivers...", platform.numberReceivers);
+	
+		receivers.forEach(function(receiver) {
+			var accessory = new OnkyoAccessory(platform, receiver);
+			// platform.log.info(accessory.tvService)
+			platform.receiverAccessories.push(accessory);
+		})
 	}
-			newobj = newobj + '{ "code":"2B" , "label":"network" } ]}';
-	RxInputs = JSON.parse(newobj);
 
-// Status Polling
-	if (this.switchHandling == "poll") {
-		var powerurl = this.status_url;
-		that.log.debug("start long poller..");
-// PWR Polling
-		var statusemitter = pollingtoevent(function(done) {
-			that.log.debug("start PWR polling..");
-			that.getPowerState( function( error, response) {
-				//pass also the setAttempt, to force a homekit update if needed
-				done(error, response, that.setAttempt);
-			}, "statuspoll");
-		}, {longpolling:true,interval:that.interval * 1000,longpollEventName:"statuspoll"});
-
-		statusemitter.on("statuspoll", function(data) {
-			that.state = data;
-			that.log.debug("event - PWR status poller - new state: ", that.state);
-			if (that.tvService ) {
-				that.tvService.getCharacteristic(Characteristic.Active).updateValue(that.state, null, "statuspoll");
-			}
-		});
-// Audio-Input Polling
-		var i_statusemitter = pollingtoevent(function(done) {
-			that.log.debug("start INPUT polling..");
-			that.getInputSource( function( error, response) {
-				//pass also the setAttempt, to force a homekit update if needed
-				done(error, response, that.setAttempt);
-			}, "i_statuspoll");
-		}, {longpolling:true,interval:that.interval * 1000,longpollEventName:"i_statuspoll"});
-
-		i_statusemitter.on("i_statuspoll", function(data) {
-			that.i_state = data;
-			that.log.debug("event - INPUT status poller - new i_state: ", that.i_state);
-			if (that.tvService ) {
-				that.tvService.getCharacteristic(Characteristic.ActiveIdentifier).updateValue(that.i_state, null, "i_statuspoll");
-			}
-		});
-// Audio-Muting Polling
-		var m_statusemitter = pollingtoevent(function(done) {
-			that.log.debug("start MUTE polling..");
-			that.getMuteState( function( error, response) {
-				//pass also the setAttempt, to force a homekit update if needed
-				done(error, response, that.setAttempt);
-			}, "m_statuspoll");
-		}, {longpolling:true,interval:that.interval * 1000,longpollEventName:"m_statuspoll"});
-
-		m_statusemitter.on("m_statuspoll", function(data) {
-			that.m_state = data;
-			that.log.debug("event - MUTE status poller - new m_state: ", that.m_state);
-			if (that.tvService ) {
-				that.tvService.getCharacteristic(Characteristic.Mute).updateValue(that.m_state, null, "m_statuspoll");
-			}
-		});
-// Volume Polling
-		var v_statusemitter = pollingtoevent(function(done) {
-			that.log.debug("start VOLUME polling..");
-			that.getVolumeState( function( error, response) {
-				//pass also the setAttempt, to force a homekit update if needed
-				done(error, response, that.setAttempt);
-			}, "v_statuspoll");
-		}, {longpolling:true,interval:that.interval * 1000,longpollEventName:"v_statuspoll"});
-
-		v_statusemitter.on("v_statuspoll", function(data) {
-			that.v_state = data;
-			that.log.debug("event - VOLUME status poller - new v_state: ", that.v_state);
-			if (that.tvService ) {
-				that.tvService.getCharacteristic(Characteristic.Volume).updateValue(that.v_state, null, "v_statuspoll");
-			}
-		});
+	accessories (callback) {
+		callback(this.receiverAccessories);
+		// return this.receiverAccessories;
 	}
 }
 
-OnkyoAccessory.prototype = {
 
-eventDebug: function( response)
-{
-	this.log.debug( "eventDebug: %s", response);
-},
+class OnkyoAccessory {	
+	constructor (platform, receiver) {
+		this.platform = platform;
+		this.log = platform.log;
 
-eventError: function( response)
-{
-	this.log.error( "eventError: %s", response);
-},
+		this.eiscp = require('eiscp');
+		this.setAttempt = 0;
+		this.enabledServices = [];
 
-eventConnect: function( response)
-{
-	this.log.debug( "eventConnect: %s", response);
-	this.reachable = true;
-},
+		const config = receiver;
+		this.name = config["name"];
+		this.ip_address	= config["ip_address"];
+		this.model = config["model"];
+		this.zone = config["zone"] || "main";
+		this.inputs = config["inputs"];
+		this.volume_dimmer = config["volume_dimmer"] || false;
+		this.switch_service = config["switch_service"] || false;
 
-eventSystemPower: function( response)
-{
-	this.state = (response == "on");
-	this.log.info("eventSystemPower - message: %s, new state %s", response, this.state);
-	//Communicate status
-	if (this.tvService ) {
-		this.tvService.getCharacteristic(Characteristic.Active).updateValue(this.state, null, "statuspoll");
-	}
-},
 
-eventAudioMuting: function( response)
-{
-	this.m_state = (response == "on");
-	this.log.debug("eventAudioMuting - message: %s, new m_state %s", response, this.m_state);
-	//Communicate status
-	if (this.tvService ) {
-		this.tvService.getCharacteristic(Characteristic.Mute).updateValue(this.m_state, null, "m_statuspoll");
-	}
-},
+		this.cmdMap = new Array();
+		this.cmdMap["main"] = new Array();
+		this.cmdMap["main"]["power"] = "system-power";
+		this.cmdMap["main"]["volume"] = "master-volume";
+		this.cmdMap["main"]["muting"] = "audio-muting";
+		this.cmdMap["main"]["input"] = "input-selector";
+		this.cmdMap["zone2"] = new Array();
+		this.cmdMap["zone2"]["power"] = "power";
+		this.cmdMap["zone2"]["volume"] = "volume";
+		this.cmdMap["zone2"]["muting"] = "muting";
+		this.cmdMap["zone2"]["input"] = "selector";
 
-eventInput: function( response)
-{
-	if (response) {
-		var input = JSON.stringify(response);
-		input = input.replace(/[\[\]"]+/g,'');
-		if (input.includes(',')) {
-			input = input.substring(0,input.indexOf(','));
+		this.poll_status_interval = config["poll_status_interval"] || "0";
+		this.defaultInput = config["default_input"];
+		this.defaultVolume = config['default_volume'];
+		this.maxVolume = config['max_volume'] || 30;
+		this.mapVolume100 = config['map_volume_100'] || false;
+
+		this.buttons = {
+			[Characteristic.RemoteKey.ARROW_UP]: 'up',
+			[Characteristic.RemoteKey.ARROW_DOWN]: 'down',
+			[Characteristic.RemoteKey.ARROW_LEFT]: 'left',
+			[Characteristic.RemoteKey.ARROW_RIGHT]: 'right',
+			[Characteristic.RemoteKey.SELECT]: 'enter',
+			[Characteristic.RemoteKey.BACK]: 'exit',
+			[Characteristic.RemoteKey.EXIT]: 'exit',
+			[Characteristic.RemoteKey.INFORMATION]: 'home',
+		};
+
+		this.state = false;
+		this.m_state = false;
+		this.v_state = 0;
+		this.i_state = 1;
+		this.interval = parseInt( this.poll_status_interval);
+		this.avrManufacturer = "Onkyo";
+		this.avrSerial = this.ip_address;
+
+		// this.eiscp.discover(function(err,result){
+		// 	if(err) {
+		// 		this.log.debug("Onkyo - ERROR - No RX found. Result: %s", result);
+		//    } else {
+		// 		this.log.debug("Onkyo - Found these receivers on the local network. Connecting to first...");
+		// 		this.log.debug(result);
+		// 		this.avrSerial = result[0].mac;
+		//    }
+		// });
+
+		this.switchHandling = "check";
+		if (this.interval > 10 && this.interval < 100000) {
+			this.switchHandling = "poll";
 		}
-		// Convert to number for input slider and i_state
-		for (var a in RxInputs.Inputs) {
-			if (RxInputs.Inputs[a].label == input) {
-				this.i_state = a;
-				break;
-			}
-		}
-		this.log.info("eventInput - message: %s - new i_state: %s - input: %s", response, this.i_state, input);
 
-		//Communicate status
-		if (this.tvService ) {
-			this.tvService.setCharacteristic(RxTypes.InputLabel,input);
-			this.tvService.getCharacteristic(RxTypes.InputSource).updateValue(this.i_state, null, "i_statuspoll");
-		}
-	} else {
-		// Then invalid Input chosen
-		this.log.error("eventInput - ERROR - INVALID INPUT - Model does not support selected input.");
+		this.eiscp.on('debug', this.eventDebug.bind(this));
+		this.eiscp.on('error', this.eventError.bind(this));
+		this.eiscp.on('connect', this.eventConnect.bind(this));
+		this.eiscp.on('close', this.eventClose.bind(this));
+		this.eiscp.on(this.cmdMap[this.zone]["power"], this.eventSystemPower.bind(this));
+		this.eiscp.on(this.cmdMap[this.zone]["volume"], this.eventVolume.bind(this));
+		this.eiscp.on(this.cmdMap[this.zone]["muting"], this.eventAudioMuting.bind(this));
+		this.eiscp.on(this.cmdMap[this.zone]["input"], this.eventInput.bind(this));
 
-		//Update input label status
-		if (this.tvService ) {
-			this.tvService.setCharacteristic(RxTypes.InputLabel,"INVALID");
-		}
+		this.eiscp.connect(
+			{host: this.ip_address, reconnect: true, model: this.model}
+		);
+
+		this.createRxInput();
+		this.polling(this);
+
+		this.setUp();
 	}
-},
-
-eventVolume: function( response)
-{
-	if (this.mapVolume100) {
-        var volumeMultiplier = this.maxVolume/100;
-        var newVolume = response / volumeMultiplier;
-		this.v_state = round(newVolume);
-		this.log.debug("eventVolume - message: %s, new v_state %s PERCENT", response, this.v_state);
-	} else {
-		this.v_state = response;
-		this.log.debug("eventVolume - message: %s, new v_state %s ACTUAL", response, this.v_state);
-	}
-	//Communicate status
-	if (this.tvService ) {
-		this.tvService.getCharacteristic(Characteristic.Volume).updateValue(this.v_state, null, "v_statuspoll");
-	}
-},
-
-eventClose: function( response)
-{
-	this.log.debug( "eventClose: %s", response);
-	this.reachable = false;
-},
-
-setPowerState: function(powerOn, callback, context) {
-	var that = this;
-//if context is statuspoll, then we need to ensure that we do not set the actual value
-	if (context && context == "statuspoll") {
-		this.log.debug( "setPowerState - polling mode, ignore, state: %s", this.state);
-		callback(null, this.state);
-	    return;
-	}
-    if (!this.ip_address) {
-    	this.log.error("Ignoring request; No ip_address defined.");
-	    callback(new Error("No ip_address defined."));
-	    return;
-    }
-
-	this.setAttempt = this.setAttempt+1;
-
-	//do the callback immediately, to free homekit
-	//have the event later on execute changes
-	that.state = powerOn;
-	callback( null, that.state);
-    if (powerOn) {
-		this.log.debug("setPowerState - actual mode, power state: %s, switching to ON", that.state);
-		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["power"] + "=on", function(error, response) {
-			//that.log.debug( "PWR ON: %s - %s -- current state: %s", error, response, that.state);
-			if (error) {
-				that.state = false;
-				that.log.error( "setPowerState - PWR ON: ERROR - current state: %s", that.state);
-				if (that.tvService ) {
-					that.tvService.getCharacteristic(Characteristic.Active).updateValue(powerOn, null, "statuspoll");
+	
+	createRxInput() {
+	// Create the RxInput object for later use.
+		var eiscpData = require('./node_modules/eiscp/eiscp-commands.json');
+		eiscpData = eiscpData.commands.main.SLI.values;
+		var newobj = '{ "Inputs" : [';
+		for (var exkey in eiscpData) {
+				var hold = eiscpData[exkey].name.toString();
+				if (hold.includes(',')) {
+						hold = hold.substring(0,hold.indexOf(','));
 				}
-			} else {
-				// If the AVR has just been turned on, apply the default volume
-					this.log.debug("Attempting to set the default volume to "+this.defaultVolume);
-					if (powerOn && this.defaultVolume) {
-						that.log.info("Setting default volume to "+this.defaultVolume);
-						this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["volume"] + ":"+this.defaultVolume, function(error, response) {
-							if (error) {
-								that.log.error( "Error while setting default volume: %s", error);
-							}
-						});
-					}
-				// If the AVR has just been turned on, apply the Input default
-					this.log.debug("Attempting to set the default input selector to "+this.defaultInput);
-					if (powerOn && this.defaultInput) {
-						that.log.info("Setting default input selector to "+this.defaultInput);
-						this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["input"] + "="+this.defaultInput, function(error, response) {
-							if (error) {
-								that.log.error( "Error while setting default input: %s", error);
-							}
-						});
-					}
-			}
-		}.bind(this) );
-	} else {
-		this.log.debug("setPowerState - actual mode, power state: %s, switching to OFF", that.state);
-		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["power"] + "=standby", function(error, response) {
-			//that.log.debug( "PWR OFF: %s - %s -- current state: %s", error, response, that.state);
-			if (error) {
-				that.state = false;
-				that.log.error( "setPowerState - PWR OFF: ERROR - current state: %s", that.state);
+		if (exkey.includes('“') || exkey.includes('“')) {
+			exkey = exkey.replace(/\“/g, "");
+			exkey = exkey.replace(/\”/g, "");
+		}
+				newobj = newobj + '{ "code":"'+exkey+'" , "label":"'+hold+'" },';
+		}
+				newobj = newobj + '{ "code":"2B" , "label":"network" } ]}';
+		RxInputs = JSON.parse(newobj);
+	}
+
+	polling(platform) {
+		var that = platform
+	// Status Polling
+		if (that.switchHandling == "poll") {
+			var powerurl = that.status_url;
+			that.log.debug("start long poller..");
+	// PWR Polling
+			var statusemitter = pollingtoevent(function(done) {
+				that.log.debug("start PWR polling..");
+				that.getPowerState( function( error, response) {
+					//pass also the setAttempt, to force a homekit update if needed
+					done(error, response, that.setAttempt);
+				}, "statuspoll");
+			}, {longpolling:true,interval:that.interval * 1000,longpollEventName:"statuspoll"});
+
+			statusemitter.on("statuspoll", function(data) {
+				that.state = data;
+				that.log.debug("event - PWR status poller - new state: ", that.state);
 				if (that.tvService ) {
 					that.tvService.getCharacteristic(Characteristic.Active).updateValue(that.state, null, "statuspoll");
 				}
-			}
-		}.bind(this) );
-    }
-},
+			});
+	// Audio-Input Polling
+			var i_statusemitter = pollingtoevent(function(done) {
+				that.log.debug("start INPUT polling..");
+				that.getInputSource( function( error, response) {
+					//pass also the setAttempt, to force a homekit update if needed
+					done(error, response, that.setAttempt);
+				}, "i_statuspoll");
+			}, {longpolling:true,interval:that.interval * 1000,longpollEventName:"i_statuspoll"});
 
-getPowerState: function(callback, context) {
-	var that = this;
-	//if context is statuspoll, then we need to request the actual value
-	if (!context || context != "statuspoll") {
-		if (this.switchHandling == "poll") {
-			this.log.debug("getPowerState - polling mode, return state: ", this.state);
+			i_statusemitter.on("i_statuspoll", function(data) {
+				that.i_state = data;
+				that.log.debug("event - INPUT status poller - new i_state: ", that.i_state);
+				if (that.tvService ) {
+					that.tvService.getCharacteristic(Characteristic.ActiveIdentifier).updateValue(that.i_state, null, "i_statuspoll");
+				}
+			});
+	// Audio-Muting Polling
+			var m_statusemitter = pollingtoevent(function(done) {
+				that.log.debug("start MUTE polling..");
+				that.getMuteState( function( error, response) {
+					//pass also the setAttempt, to force a homekit update if needed
+					done(error, response, that.setAttempt);
+				}, "m_statuspoll");
+			}, {longpolling:true,interval:that.interval * 1000,longpollEventName:"m_statuspoll"});
+
+			m_statusemitter.on("m_statuspoll", function(data) {
+				that.m_state = data;
+				that.log.debug("event - MUTE status poller - new m_state: ", that.m_state);
+				if (that.tvService ) {
+					that.tvService.getCharacteristic(Characteristic.Mute).updateValue(that.m_state, null, "m_statuspoll");
+				}
+			});
+	// Volume Polling
+			var v_statusemitter = pollingtoevent(function(done) {
+				that.log.debug("start VOLUME polling..");
+				that.getVolumeState( function( error, response) {
+					//pass also the setAttempt, to force a homekit update if needed
+					done(error, response, that.setAttempt);
+				}, "v_statuspoll");
+			}, {longpolling:true,interval:that.interval * 1000,longpollEventName:"v_statuspoll"});
+
+			v_statusemitter.on("v_statuspoll", function(data) {
+				that.v_state = data;
+				that.log.debug("event - VOLUME status poller - new v_state: ", that.v_state);
+				if (that.tvService ) {
+					that.tvService.getCharacteristic(Characteristic.Volume).updateValue(that.v_state, null, "v_statuspoll");
+				}
+			});
+		}
+	}
+
+	///////////////////
+	// EVENT FUNCTIONS
+	///////////////////
+	eventDebug(response) {
+		this.log.debug( "eventDebug: %s", response);
+	}
+
+	eventError(response) {
+		this.log.error( "eventError: %s", response);
+	}
+
+	eventConnect(response) {
+		this.log.debug( "eventConnect: %s", response);
+		this.reachable = true;
+	}
+
+	eventSystemPower(response) {
+		this.state = (response == "on");
+		this.log.info("eventSystemPower - message: %s, new state %s", response, this.state);
+		//Communicate status
+		if (this.tvService ) {
+			this.tvService.getCharacteristic(Characteristic.Active).updateValue(this.state, null, "statuspoll");
+		}
+	}
+
+	eventAudioMuting(response) {
+		this.m_state = (response == "on");
+		this.log.debug("eventAudioMuting - message: %s, new m_state %s", response, this.m_state);
+		//Communicate status
+		if (this.tvService ) {
+			this.tvService.getCharacteristic(Characteristic.Mute).updateValue(this.m_state, null, "m_statuspoll");
+		}
+	}
+
+	eventInput(response) {
+		if (response) {
+			var input = JSON.stringify(response);
+			input = input.replace(/[\[\]"]+/g,'');
+			if (input.includes(',')) {
+				input = input.substring(0,input.indexOf(','));
+			}
+			// Convert to number for input slider and i_state
+			for (var a in RxInputs.Inputs) {
+				if (RxInputs.Inputs[a].label == input) {
+					this.i_state = a;
+					break;
+				}
+			}
+			this.log.info("eventInput - message: %s - new i_state: %s - input: %s", response, this.i_state, input);
+
+			//Communicate status
+			if (this.tvService ) {
+				this.tvService.setCharacteristic(RxTypes.InputLabel,input);
+				this.tvService.getCharacteristic(RxTypes.InputSource).updateValue(this.i_state, null, "i_statuspoll");
+			}
+		} else {
+			// Then invalid Input chosen
+			this.log.error("eventInput - ERROR - INVALID INPUT - Model does not support selected input.");
+
+			//Update input label status
+			if (this.tvService ) {
+				this.tvService.setCharacteristic(RxTypes.InputLabel,"INVALID");
+			}
+		}
+	}
+
+	eventVolume(response) {
+		if (this.mapVolume100) {
+			var volumeMultiplier = this.maxVolume/100;
+			var newVolume = response / volumeMultiplier;
+			this.v_state = round(newVolume);
+			this.log.debug("eventVolume - message: %s, new v_state %s PERCENT", response, this.v_state);
+		} else {
+			this.v_state = response;
+			this.log.debug("eventVolume - message: %s, new v_state %s ACTUAL", response, this.v_state);
+		}
+		//Communicate status
+		if (this.tvService ) {
+			this.tvService.getCharacteristic(Characteristic.Volume).updateValue(this.v_state, null, "v_statuspoll");
+		}
+	}
+
+	eventClose (response) {
+		this.log.debug( "eventClose: %s", response);
+		this.reachable = false;
+	}
+
+	////////////////////////
+	// GET AND SET FUNCTIONS
+	////////////////////////
+	setPowerState(powerOn, callback, context) {
+	//if context is statuspoll, then we need to ensure this we do not set the actual value
+		if (context && context == "statuspoll") {
+			this.log.debug( "setPowerState - polling mode, ignore, state: %s", this.state);
 			callback(null, this.state);
 			return;
 		}
+		if (!this.ip_address) {
+			this.log.error("Ignoring request; No ip_address defined.");
+			callback(new Error("No ip_address defined."));
+			return;
+		}
+	
+		this.setAttempt = this.setAttempt+1;
+	
+		//do the callback immediately, to free homekit
+		//have the event later on execute changes
+		this.state = powerOn;
+		callback( null, this.state);
+		if (powerOn) {
+			this.log.debug("setPowerState - actual mode, power state: %s, switching to ON", this.state);
+			this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["power"] + "=on", function(error, response) {
+				//this.log.debug( "PWR ON: %s - %s -- current state: %s", error, response, this.state);
+				if (error) {
+					this.state = false;
+					this.log.error( "setPowerState - PWR ON: ERROR - current state: %s", this.state);
+					if (this.tvService ) {
+						this.tvService.getCharacteristic(Characteristic.Active).updateValue(powerOn, null, "statuspoll");
+					}
+				} else {
+					// If the AVR has just been turned on, apply the default volume
+						this.log.debug("Attempting to set the default volume to "+this.defaultVolume);
+						if (powerOn && this.defaultVolume) {
+							this.log.info("Setting default volume to "+this.defaultVolume);
+							this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["volume"] + ":"+this.defaultVolume, function(error, response) {
+								if (error) {
+									this.log.error( "Error while setting default volume: %s", error);
+								}
+							});
+						}
+					// If the AVR has just been turned on, apply the Input default
+						this.log.debug("Attempting to set the default input selector to "+this.defaultInput);
+						if (powerOn && this.defaultInput) {
+							this.log.info("Setting default input selector to "+this.defaultInput);
+							this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["input"] + "="+this.defaultInput, function(error, response) {
+								if (error) {
+									this.log.error( "Error while setting default input: %s", error);
+								}
+							});
+						}
+				}
+			}.bind(this) );
+		} else {
+			this.log.debug("setPowerState - actual mode, power state: %s, switching to OFF", this.state);
+			this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["power"] + "=standby", function(error, response) {
+				//this.log.debug( "PWR OFF: %s - %s -- current state: %s", error, response, this.state);
+				if (error) {
+					this.state = false;
+					this.log.error( "setPowerState - PWR OFF: ERROR - current state: %s", this.state);
+					if (this.tvService ) {
+						this.tvService.getCharacteristic(Characteristic.Active).updateValue(this.state, null, "statuspoll");
+					}
+				}
+			}.bind(this) );
+		}
 	}
-
-    if (!this.ip_address) {
-    	this.log.error("Ignoring request; No ip_address defined.");
-	    callback(new Error("No ip_address defined."));
-	    return;
-    }
-
-	//do the callback immediately, to free homekit
-	//have the event later on execute changes
-	callback(null, this.state);
-    this.log.debug("getPowerState - actual mode, return state: ", this.state);
-	this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["power"] + "=query", function( error, data) {
-		if (error) {
-			that.state = false;
-			that.log.debug( "getPowerState - PWR QRY: ERROR - current state: %s", that.state);
-			if (that.tvService ) {
-				that.tvService.getCharacteristic(Characteristic.Active).updateValue(that.state, null, "statuspoll");
+	
+	getPowerState(callback, context) {
+		//if context is statuspoll, then we need to request the actual value
+		if (!context || context != "statuspoll") {
+			if (this.switchHandling == "poll") {
+				this.log.debug("getPowerState - polling mode, return state: ", this.state);
+				callback(null, this.state);
+				return;
 			}
 		}
-	}.bind(this) );
-},
-
-getVolumeState: function(callback, context) {
-	var that = this;
-	//if context is v_statuspoll, then we need to request the actual value
-	if (!context || context != "v_statuspoll") {
-		if (this.switchHandling == "poll") {
-			this.log.debug("getVolumeState - polling mode, return v_state: ", this.v_state);
+	
+		if (!this.ip_address) {
+			this.log.error("Ignoring request; No ip_address defined.");
+			callback(new Error("No ip_address defined."));
+			return;
+		}
+	
+		//do the callback immediately, to free homekit
+		//have the event later on execute changes
+		callback(null, this.state);
+		this.log.debug("getPowerState - actual mode, return state: ", this.state);
+		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["power"] + "=query", function( error, data) {
+			if (error) {
+				this.state = false;
+				this.log.debug( "getPowerState - PWR QRY: ERROR - current state: %s", this.state);
+				if (this.tvService ) {
+					this.tvService.getCharacteristic(Characteristic.Active).updateValue(this.state, null, "statuspoll");
+				}
+			}
+		}.bind(this) );
+	}
+	
+	getVolumeState(callback, context) {
+		//if context is v_statuspoll, then we need to request the actual value
+		if (!context || context != "v_statuspoll") {
+			if (this.switchHandling == "poll") {
+				this.log.debug("getVolumeState - polling mode, return v_state: ", this.v_state);
+				callback(null, this.v_state);
+				return;
+			}
+		}
+	
+		if (!this.ip_address) {
+			this.log.error("Ignoring request; No ip_address defined.");
+			callback(new Error("No ip_address defined."));
+			return;
+		}
+	
+		//do the callback immediately, to free homekit
+		//have the event later on execute changes
+		callback(null, this.v_state);
+		this.log.debug("getVolumeState - actual mode, return v_state: ", this.v_state);
+		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["volume"] + "=query", function( error, data) {
+			if (error) {
+				this.v_state = 0;
+				this.log.debug( "getVolumeState - VOLUME QRY: ERROR - current v_state: %s", this.v_state);
+				if (this.tvService ) {
+					this.tvService.getCharacteristic(Characteristic.Volume).updateValue(this.v_state, null, "v_statuspoll");
+				}
+			}
+		}.bind(this) );
+	}
+	
+	setVolumeState(volumeLvl, callback, context) {
+	//if context is v_statuspoll, then we need to ensure this we do not set the actual value
+		if (context && context == "v_statuspoll") {
+			this.log.debug( "setVolumeState - polling mode, ignore, v_state: %s", this.v_state);
 			callback(null, this.v_state);
 			return;
 		}
-	}
-
-    if (!this.ip_address) {
-    	this.log.error("Ignoring request; No ip_address defined.");
-	    callback(new Error("No ip_address defined."));
-	    return;
-    }
-
-	//do the callback immediately, to free homekit
-	//have the event later on execute changes
-	callback(null, this.v_state);
-    this.log.debug("getVolumeState - actual mode, return v_state: ", this.v_state);
-	this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["volume"] + "=query", function( error, data) {
-		if (error) {
-			that.v_state = 0;
-			that.log.debug( "getVolumeState - VOLUME QRY: ERROR - current v_state: %s", that.v_state);
-			if (that.tvService ) {
-				that.tvService.getCharacteristic(Characteristic.Volume).updateValue(that.v_state, null, "v_statuspoll");
-			}
+		if (!this.ip_address) {
+			this.log.error("Ignoring request; No ip_address defined.");
+			callback(new Error("No ip_address defined."));
+			return;
 		}
-	}.bind(this) );
-},
-
-setVolumeState: function(volumeLvl, callback, context) {
-	var that = this;
-//if context is v_statuspoll, then we need to ensure that we do not set the actual value
-	if (context && context == "v_statuspoll") {
-		this.log.debug( "setVolumeState - polling mode, ignore, v_state: %s", this.v_state);
-		callback(null, this.v_state);
-	    return;
-	}
-    if (!this.ip_address) {
-    	this.log.error("Ignoring request; No ip_address defined.");
-	    callback(new Error("No ip_address defined."));
-	    return;
-    }
-
-	this.setAttempt = this.setAttempt+1;
-
-	//Are we mapping volume to 100%?
-	if (this.mapVolume100) {
-        var volumeMultiplier = this.maxVolume/100;
-        var newVolume = volumeMultiplier * volumeLvl;
-		this.v_state = round(newVolume);
-		this.log.debug("setVolumeState - actual mode, PERCENT, volume v_state: %s", that.v_state);
-	} else if (volumeLvl > this.maxVolume) {
-	//Determin if maxVolume threshold breached, if so set to max.
-		that.v_state = this.maxVolume;
-		this.log.debug("setVolumeState - VOLUME LEVEL of: %s exceeds maxVolume: %s. Resetting to max.", volumeLvl, this.maxVolume);
-	} else {
-	// Must be using actual volume number
-		that.v_state = volumeLvl;
-		this.log.debug("setVolumeState - actual mode, ACTUAL volume v_state: %s", that.v_state);
-	}
-
-	//do the callback immediately, to free homekit
-	//have the event later on execute changes
-	callback( null, that.v_state);
-
-	this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["volume"] + ":" + that.v_state, function(error, response) {
-		if (error) {
-			that.v_state = 0;
-			that.log.debug( "setVolumeState - VOLUME : ERROR - current v_state: %s", that.v_state);
-			if (that.switchService ) {
-				that.switchService.getCharacteristic(Characteristic.Volume).updateValue(that.v_state, null, "v_statuspoll");
-			}
+	
+		this.setAttempt = this.setAttempt+1;
+	
+		//Are we mapping volume to 100%?
+		if (this.mapVolume100) {
+			var volumeMultiplier = this.maxVolume/100;
+			var newVolume = volumeMultiplier * volumeLvl;
+			this.v_state = round(newVolume);
+			this.log.debug("setVolumeState - actual mode, PERCENT, volume v_state: %s", this.v_state);
+		} else if (volumeLvl > this.maxVolume) {
+		//Determin if maxVolume threshold breached, if so set to max.
+			this.v_state = this.maxVolume;
+			this.log.debug("setVolumeState - VOLUME LEVEL of: %s exceeds maxVolume: %s. Resetting to max.", volumeLvl, this.maxVolume);
+		} else {
+		// Must be using actual volume number
+			this.v_state = volumeLvl;
+			this.log.debug("setVolumeState - actual mode, ACTUAL volume v_state: %s", this.v_state);
 		}
-	}.bind(this) );
-},
-
-setVolumeRelative: function(volumeDirection, callback, context) {
-	var that = this;
-//if context is v_statuspoll, then we need to ensure that we do not set the actual value
-	if (context && context == "v_statuspoll") {
-		this.log.debug( "setVolumeRelative - polling mode, ignore, v_state: %s", this.v_state);
-		callback(null, this.v_state);
-	    return;
-	}
-    if (!this.ip_address) {
-    	this.log.error("Ignoring request; No ip_address defined.");
-	    callback(new Error("No ip_address defined."));
-	    return;
-    }
-
-	this.setAttempt = this.setAttempt+1;
-
-	//do the callback immediately, to free homekit
-	//have the event later on execute changes
-	callback( null, that.v_state);
-	if (volumeDirection == Characteristic.VolumeSelector.INCREMENT) {
-		this.log.debug("setVolumeRelative - VOLUME : level-up")
-		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["volume"] + ":" + "level-up", function(error, response) {
+	
+		//do the callback immediately, to free homekit
+		//have the event later on execute changes
+		callback( null, this.v_state);
+	
+		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["volume"] + ":" + this.v_state, function(error, response) {
 			if (error) {
-				that.v_state = 0;
-				that.log.error( "setVolumeRelative - VOLUME : ERROR - current v_state: %s", that.v_state);
+				this.v_state = 0;
+				this.log.debug( "setVolumeState - VOLUME : ERROR - current v_state: %s", this.v_state);
+				if (this.switchService ) {
+					this.switchService.getCharacteristic(Characteristic.Volume).updateValue(this.v_state, null, "v_statuspoll");
+				}
 			}
 		}.bind(this) );
-	} else if (volumeDirection == Characteristic.VolumeSelector.DECREMENT) {
-		this.log.debug("setVolumeRelative - VOLUME : level-down")
-		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["volume"] + ":" + "level-down", function(error, response) {
+	}
+	
+	setVolumeRelative(volumeDirection, callback, context) {
+	//if context is v_statuspoll, then we need to ensure this we do not set the actual value
+		if (context && context == "v_statuspoll") {
+			this.log.debug( "setVolumeRelative - polling mode, ignore, v_state: %s", this.v_state);
+			callback(null, this.v_state);
+			return;
+		}
+		if (!this.ip_address) {
+			this.log.error("Ignoring request; No ip_address defined.");
+			callback(new Error("No ip_address defined."));
+			return;
+		}
+	
+		this.setAttempt = this.setAttempt+1;
+	
+		//do the callback immediately, to free homekit
+		//have the event later on execute changes
+		callback( null, this.v_state);
+		if (volumeDirection == Characteristic.VolumeSelector.INCREMENT) {
+			this.log.debug("setVolumeRelative - VOLUME : level-up")
+			this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["volume"] + ":" + "level-up", function(error, response) {
+				if (error) {
+					this.v_state = 0;
+					this.log.error( "setVolumeRelative - VOLUME : ERROR - current v_state: %s", this.v_state);
+				}
+			}.bind(this) );
+		} else if (volumeDirection == Characteristic.VolumeSelector.DECREMENT) {
+			this.log.debug("setVolumeRelative - VOLUME : level-down")
+			this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["volume"] + ":" + "level-down", function(error, response) {
+				if (error) {
+					this.v_state = 0;
+					this.log.error( "setVolumeRelative - VOLUME : ERROR - current v_state: %s", this.v_state);
+				}
+			}.bind(this) );
+		} else {
+			this.log.error( "setVolumeRelative - VOLUME : ERROR - unknown direction sent");
+		}
+	}
+	
+	getMuteState(callback, context) {
+		//if context is m_statuspoll, then we need to request the actual value
+		if (!context || context != "m_statuspoll") {
+			if (this.switchHandling == "poll") {
+				this.log.debug("getMuteState - polling mode, return m_state: ", this.m_state);
+				callback(null, this.m_state);
+				return;
+			}
+		}
+	
+		if (!this.ip_address) {
+			this.log.error("Ignoring request; No ip_address defined.");
+			callback(new Error("No ip_address defined."));
+			return;
+		}
+	
+		//do the callback immediately, to free homekit
+		//have the event later on execute changes
+		callback(null, this.m_state);
+		this.log.debug("getMuteState - actual mode, return m_state: ", this.m_state);
+		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["muting"] + "=query", function( error, data) {
 			if (error) {
-				that.v_state = 0;
-				that.log.error( "setVolumeRelative - VOLUME : ERROR - current v_state: %s", that.v_state);
+				this.m_state = false;
+				this.log.debug( "getMuteState - MUTE QRY: ERROR - current m_state: %s", this.m_state);
+				if (this.tvService ) {
+					this.tvService.getCharacteristic(Characteristic.Mute).updateValue(this.m_state, null, "m_statuspoll");
+				}
 			}
 		}.bind(this) );
-	} else {
-		that.log.error( "setVolumeRelative - VOLUME : ERROR - unknown direction sent");
 	}
-},
-
-getMuteState: function(callback, context) {
-	var that = this;
-	//if context is m_statuspoll, then we need to request the actual value
-	if (!context || context != "m_statuspoll") {
-		if (this.switchHandling == "poll") {
-			this.log.debug("getMuteState - polling mode, return m_state: ", this.m_state);
+	
+	setMuteState(muteOn, callback, context) {
+	//if context is m_statuspoll, then we need to ensure this we do not set the actual value
+		if (context && context == "m_statuspoll") {
+			this.log.debug( "setMuteState - polling mode, ignore, m_state: %s", this.m_state);
 			callback(null, this.m_state);
 			return;
 		}
+		if (!this.ip_address) {
+			this.log.error("Ignoring request; No ip_address defined.");
+			callback(new Error("No ip_address defined."));
+			return;
+		}
+	
+		this.setAttempt = this.setAttempt+1;
+	
+		//do the callback immediately, to free homekit
+		//have the event later on execute changes
+		this.m_state = muteOn;
+		callback( null, this.m_state);
+		if (this.m_state) {
+			this.log.debug("setMuteState - actual mode, mute m_state: %s, switching to ON", this.m_state);
+			this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["muting"] + "=on", function(error, response) {
+				if (error) {
+					this.m_state = false;
+					this.log.error( "setMuteState - MUTE ON: ERROR - current m_state: %s", this.m_state);
+					if (this.tvService ) {
+						this.tvService.getCharacteristic(Characteristic.Mute).updateValue(this.m_state, null, "m_statuspoll");
+					}
+				}
+			}.bind(this) );
+		} else {
+			this.log.debug("setMuteState - actual mode, mute m_state: %s, switching to OFF", this.m_state);
+			this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["muting"] + "=off", function(error, response) {
+				if (error) {
+					this.m_state = false;
+					this.log.error( "setMuteState - MUTE OFF: ERROR - current m_state: %s", this.m_state);
+					if (this.tvService ) {
+						this.tvService.getCharacteristic(Characteristic.Mute).updateValue(this.m_state, null, "m_statuspoll");
+					}
+				}
+			}.bind(this) );
+		}
 	}
-
-    if (!this.ip_address) {
-    	this.log.error("Ignoring request; No ip_address defined.");
-	    callback(new Error("No ip_address defined."));
-	    return;
-    }
-
-	//do the callback immediately, to free homekit
-	//have the event later on execute changes
-	callback(null, this.m_state);
-    this.log.debug("getMuteState - actual mode, return m_state: ", this.m_state);
-	this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["muting"] + "=query", function( error, data) {
-		if (error) {
-			that.m_state = false;
-			that.log.debug( "getMuteState - MUTE QRY: ERROR - current m_state: %s", that.m_state);
-			if (that.tvService ) {
-				that.tvService.getCharacteristic(Characteristic.Mute).updateValue(that.m_state, null, "m_statuspoll");
+	
+	getInputSource(callback, context) {
+		//if context is i_statuspoll, then we need to request the actual value
+		if (!context || context != "i_statuspoll") {
+			if (this.switchHandling == "poll") {
+				this.log.debug("getInputState - polling mode, return i_state: ", this.i_state);
+				callback(null, this.i_state);
+				return;
 			}
 		}
-	}.bind(this) );
-},
-
-setMuteState: function(muteOn, callback, context) {
-	var that = this;
-//if context is m_statuspoll, then we need to ensure that we do not set the actual value
-	if (context && context == "m_statuspoll") {
-		this.log.debug( "setMuteState - polling mode, ignore, m_state: %s", this.m_state);
-		callback(null, this.m_state);
-	    return;
+	
+		if (!this.ip_address) {
+			this.log.error("Ignoring request; No ip_address defined.");
+			callback(new Error("No ip_address defined."));
+			return;
+		}
+	
+		//do the callback immediately, to free homekit
+		//have the event later on execute changes
+		callback(null, this.i_state);
+		this.log.debug("getInputState - actual mode, return i_state: ", this.i_state);
+		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["input"] + "=query", function( error, data) {
+			if (error) {
+				this.i_state = 1;
+				this.log.debug( "getInputState - INPUT QRY: ERROR - current i_state: %s", this.i_state);
+				if (this.tvService ) {
+					this.tvService.setCharacteristic(RxTypes.InputLabel,"get error")
+					this.tvService.getCharacteristic(RxTypes.InputSource).updateValue(this.i_state, null, "i_statuspoll");
+				}
+			}
+		}.bind(this) );
 	}
-    if (!this.ip_address) {
-    	this.log.error("Ignoring request; No ip_address defined.");
-	    callback(new Error("No ip_address defined."));
-	    return;
-    }
-
-	this.setAttempt = this.setAttempt+1;
-
-	//do the callback immediately, to free homekit
-	//have the event later on execute changes
-	that.m_state = muteOn;
-	callback( null, that.m_state);
-    if (that.m_state) {
-		this.log.debug("setMuteState - actual mode, mute m_state: %s, switching to ON", that.m_state);
-		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["muting"] + "=on", function(error, response) {
-			if (error) {
-				that.m_state = false;
-				that.log.error( "setMuteState - MUTE ON: ERROR - current m_state: %s", that.m_state);
-				if (that.tvService ) {
-					that.tvService.getCharacteristic(Characteristic.Mute).updateValue(that.m_state, null, "m_statuspoll");
-				}
-			}
-		}.bind(this) );
-	} else {
-		this.log.debug("setMuteState - actual mode, mute m_state: %s, switching to OFF", that.m_state);
-		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["muting"] + "=off", function(error, response) {
-			if (error) {
-				that.m_state = false;
-				that.log.error( "setMuteState - MUTE OFF: ERROR - current m_state: %s", that.m_state);
-				if (that.tvService ) {
-					that.tvService.getCharacteristic(Characteristic.Mute).updateValue(that.m_state, null, "m_statuspoll");
-				}
-			}
-		}.bind(this) );
-    }
-},
-
-getInputSource: function(callback, context) {
-	var that = this;
-	//if context is i_statuspoll, then we need to request the actual value
-	if (!context || context != "i_statuspoll") {
-		if (this.switchHandling == "poll") {
-			this.log.debug("getInputState - polling mode, return i_state: ", this.i_state);
+	
+	setInputSource(source, callback, context) {
+	//if context is i_statuspoll, then we need to ensure this we do not set the actual value
+		if (context && context == "i_statuspoll") {
+			this.log.debug( "setInputState - polling mode, ignore, i_state: %s", this.i_state);
 			callback(null, this.i_state);
 			return;
 		}
-	}
-
-    if (!this.ip_address) {
-    	this.log.error("Ignoring request; No ip_address defined.");
-	    callback(new Error("No ip_address defined."));
-	    return;
-    }
-
-	//do the callback immediately, to free homekit
-	//have the event later on execute changes
-	callback(null, this.i_state);
-    this.log.debug("getInputState - actual mode, return i_state: ", this.i_state);
-	this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["input"] + "=query", function( error, data) {
-		if (error) {
-			that.i_state = 1;
-			that.log.debug( "getInputState - INPUT QRY: ERROR - current i_state: %s", that.i_state);
-			if (that.tvService ) {
-				that.tvService.setCharacteristic(RxTypes.InputLabel,"get error")
-				that.tvService.getCharacteristic(RxTypes.InputSource).updateValue(that.i_state, null, "i_statuspoll");
-			}
+		if (!this.ip_address) {
+			this.log.error("Ignoring request; No ip_address defined.");
+			callback(new Error("No ip_address defined."));
+			return;
 		}
-	}.bind(this) );
-},
-
-setInputSource: function(source, callback, context) {
-	var that = this;
-//if context is i_statuspoll, then we need to ensure that we do not set the actual value
-	if (context && context == "i_statuspoll") {
-		this.log.debug( "setInputState - polling mode, ignore, i_state: %s", this.i_state);
+	
+		this.setAttempt = this.setAttempt+1;
+		this.i_state = parseInt(source);
+		this.log.debug("setInputState - actual mode, ACTUAL input i_state: %s - label: %s", this.i_state, RxInputs.Inputs[this.i_state].label);
+	
+		//do the callback immediately, to free homekit
+		//have the event later on execute changes
 		callback(null, this.i_state);
-	    return;
-	}
-    if (!this.ip_address) {
-    	this.log.error("Ignoring request; No ip_address defined.");
-	    callback(new Error("No ip_address defined."));
-	    return;
-    }
-
-	this.setAttempt = this.setAttempt+1;
-	that.i_state = parseInt(source);
-	this.log.debug("setInputState - actual mode, ACTUAL input i_state: %s - label: %s", that.i_state, RxInputs.Inputs[that.i_state].label);
-
-	//do the callback immediately, to free homekit
-	//have the event later on execute changes
-	callback(null, that.i_state);
-
-	this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["input"] + ":" + RxInputs.Inputs[that.i_state].label, function(error, response) {
-		if (error) {
-			that.log.debug( "setInputState - INPUT : ERROR - current i_state:%s - Source:%s", that.i_state, source.toString());
-			if (that.tvService ) {
-				that.tvService.setCharacteristic(RxTypes.InputLabel,"set error")
-				that.tvService.getCharacteristic(RxTypes.InputSource).updateValue(that.i_state, null, "i_statuspoll");
-			}
-		}
-	}.bind(this) );
-},
-
-remoteKeyPress: function(button, callback) {
-	//do the callback immediately, to free homekit
-	//have the event later on execute changes
-	callback(null, this.i_state);
-	if (this.buttons[button]) {
-		var press = this.buttons[button]
-		this.log.debug("remoteKeyPress - INPUT: pressing key %s", press);
-		this.eiscp.command(this.zone + "." + "setup=" + press, function( error, data) {
+	
+		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["input"] + ":" + RxInputs.Inputs[this.i_state].label, function(error, response) {
 			if (error) {
-				that.i_state = 1;
-				that.log.error( "remoteKeyPress - INPUT: ERROR pressing button %s", press);
+				this.log.debug( "setInputState - INPUT : ERROR - current i_state:%s - Source:%s", this.i_state, source.toString());
+				if (this.tvService ) {
+					this.tvService.setCharacteristic(RxTypes.InputLabel,"set error")
+					this.tvService.getCharacteristic(RxTypes.InputSource).updateValue(this.i_state, null, "i_statuspoll");
+				}
 			}
 		}.bind(this) );
-	} else {
-		this.log.error('Remote button %d not supported.', button)
 	}
-},
+	
+	remoteKeyPress(button, callback) {
+		//do the callback immediately, to free homekit
+		//have the event later on execute changes
+		callback(null, this.i_state);
+		if (this.buttons[button]) {
+			var press = this.buttons[button]
+			this.log.debug("remoteKeyPress - INPUT: pressing key %s", press);
+			this.eiscp.command(this.zone + "." + "setup=" + press, function( error, data) {
+				if (error) {
+					this.i_state = 1;
+					this.log.error( "remoteKeyPress - INPUT: ERROR pressing button %s", press);
+				}
+			}.bind(this) );
+		} else {
+			this.log.error('Remote button %d not supported.', button)
+		}
+	}
+	
+	identify(callback) {
+		this.log.info("Identify requested! %i", this.ip_address);
+		callback(); // success
+	}
 
-identify: function(callback) {
-    this.log.info("Identify requested! %i", this.ip_address);
-    callback(); // success
-},
-
-
-addSources: function(service) {
-	// If input name mappings are provided, use them.
-	// Else, load all inputs from query (useful for finding inputs to map).
-	RxInputs['Inputs'].forEach((i, x) =>  {
-		if (this.inputs) {
-			if (this.inputs[i['label']]) {
-				var inputName = this.inputs[i['label']]
+	////////////////////////
+	// TV SERVICE FUNCTIONS
+	////////////////////////
+	addSources(service) {
+		// If input name mappings are provided, use them.
+		// Else, load all inputs from query (useful for finding inputs to map).
+		RxInputs['Inputs'].forEach((i, x) =>  {
+			if (this.inputs) {
+				if (this.inputs[i['label']]) {
+					var inputName = this.inputs[i['label']]
+					let tmpInput = new Service.InputSource(inputName, 'inputSource' + x);
+					tmpInput
+						.setCharacteristic(Characteristic.Identifier, x)
+						.setCharacteristic(Characteristic.ConfiguredName, inputName)
+						.setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED)
+						.setCharacteristic(Characteristic.InputSourceType, Characteristic.InputSourceType.HDMI);
+			
+					service.addLinkedService(tmpInput);
+					this.enabledServices.push(tmpInput);
+				}
+			} else {
+				var inputName = i['label']
 				let tmpInput = new Service.InputSource(inputName, 'inputSource' + x);
 				tmpInput
 					.setCharacteristic(Characteristic.Identifier, x)
 					.setCharacteristic(Characteristic.ConfiguredName, inputName)
 					.setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED)
-					.setCharacteristic(Characteristic.InputSourceType, Characteristic.InputSourceType.APPLICATION);
-		
+					.setCharacteristic(Characteristic.InputSourceType, Characteristic.InputSourceType.HDMI);
+	
 				service.addLinkedService(tmpInput);
 				this.enabledServices.push(tmpInput);
 			}
-		} else {
-			var inputName = i['label']
-			let tmpInput = new Service.InputSource(inputName, 'inputSource' + x);
-			tmpInput
-				.setCharacteristic(Characteristic.Identifier, x)
-				.setCharacteristic(Characteristic.ConfiguredName, inputName)
-				.setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED)
-				.setCharacteristic(Characteristic.InputSourceType, Characteristic.InputSourceType.APPLICATION);
+		})
+	
+	}
 
-			service.addLinkedService(tmpInput);
-			this.enabledServices.push(tmpInput);
-		}
-	})
+	createAccessoryInformationService() {
+		const informationService = new Service.AccessoryInformation();
+		informationService
+			.setCharacteristic(Characteristic.Manufacturer, this.avrManufacturer)
+			.setCharacteristic(Characteristic.Model, this.model)
+			.setCharacteristic(Characteristic.SerialNumber, this.avrSerial)
+			.setCharacteristic(Characteristic.FirmwareRevision, info.version)
+			.setCharacteristic(Characteristic.Name, this.name);
+	
+		this.enabledServices.push(informationService);
+	}
 
-},
-
-getServices: function() {
-	var informationService = new Service.AccessoryInformation();
-    informationService
-    .setCharacteristic(Characteristic.Manufacturer, this.avrManufacturer)
-    .setCharacteristic(Characteristic.Model, this.model)
-	.setCharacteristic(Characteristic.SerialNumber, this.avrSerial)
-	.setCharacteristic(Characteristic.FirmwareRevision, package.version);
-
-	this.enabledServices.push(informationService);
-
-	if (this.switch_service) {
+	createSwitchService() {
 		this.log.debug("Creating Switch service for receiver %s", this.name)
 		this.switchService = new Service.Switch(this.name);
 
@@ -761,14 +776,19 @@ getServices: function() {
 		this.enabledServices.push(this.switchService);
 		if (this.volume_dimmer) {
 			this.log.debug("Creating Dimmer service linked to Switch for receiver %s", this.name)
-			this.prepareVolumeDimmer(this.switchService);
+			this.createVolumeDimmer(this.switchService);
 		}
-	} else {
+	}
+
+	createTvService() {
 		this.log.debug("Creating TV service for receiver %s", this.name)
 		this.tvService = new Service.Television(this.name);
 
 		this.tvService
 			.setCharacteristic(Characteristic.ConfiguredName, this.name);
+			// .setProps({
+			// 	perms: [Characteristic.Perms.READ]
+			// });
 		
 		this.tvService
 			.setCharacteristic(Characteristic.SleepDiscoveryMode, Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE);
@@ -795,62 +815,73 @@ getServices: function() {
 			.on('set', this.remoteKeyPress.bind(this));
 			
 		this.enabledServices.push(this.tvService);
-		this.prepareTvSpeakerService();
-		if (this.volume_dimmer) {
-			this.log.debug("Creating Dimmer service linked to TV for receiver %s", this.name)
-			this.prepareVolumeDimmer(this.tvService);
+		// if (this.volume_dimmer) {
+		// 	this.log.debug("Creating Dimmer service linked to TV for receiver %s", this.name)
+		// 	this.createVolumeDimmer(this.tvService);
+		// }
+		return this.tvService;
+	}
+	
+	createTvSpeakerService(television) {
+		var tvSpeakerService = new Service.TelevisionSpeaker(this.name + ' Volume');
+		tvSpeakerService
+			.setCharacteristic(Characteristic.Active, Characteristic.Active.ACTIVE)
+			.setCharacteristic(Characteristic.VolumeControlType, Characteristic.VolumeControlType.ABSOLUTE);
+		tvSpeakerService
+			.getCharacteristic(Characteristic.VolumeSelector)
+			.on('set', this.setVolumeRelative.bind(this));
+		tvSpeakerService
+			.getCharacteristic(Characteristic.Mute)
+			.on('get', this.getMuteState.bind(this))
+			.on('set', this.setMuteState.bind(this));
+		tvSpeakerService
+			.addCharacteristic(Characteristic.Volume)
+			.on('get', this.getVolumeState.bind(this))
+			.on('set', this.setVolumeState.bind(this));
+	
+		this.log.info(tvSpeakerService);
+		
+		television.addLinkedService(this.tvSpeakerService);
+		this.enabledServices.push(this.tvSpeakerService);
+	}
+	
+	createVolumeDimmer(service) {
+		this.dimmer = new Service.Lightbulb(this.name + ' Volume', 'dimmer');
+		this.dimmer
+			.getCharacteristic(Characteristic.On)
+			// Inverted logic taken from https://github.com/langovoi/homebridge-upnp
+			.on('get', (callback) => {
+				this.getMuteState((err, value) => {
+					if (err) {
+						callback(err);
+						return;
+					}
+	
+					callback(null, !value);
+				})
+			})
+			.on('set', (value, callback) => this.setMuteState(!value, callback));
+		this.dimmer
+			.addCharacteristic(Characteristic.Brightness)
+			.on('get', this.getVolumeState.bind(this))
+			.on('set', this.setVolumeState.bind(this));
+		
+		service.addLinkedService(this.dimmer);
+		this.enabledServices.push(this.dimmer);
+	}
+
+	setUp() {
+		this.createAccessoryInformationService();
+	
+		if (this.switch_service) {
+			this.createSwitchService();
+		} else {
+			var television = this.createTvService();
+			this.createTvSpeakerService(television);
 		}
 	}
-	return this.enabledServices;
-}
-};
 
-
-OnkyoAccessory.prototype.prepareTvSpeakerService = function() {
-
-    this.tvSpeakerService = new Service.TelevisionSpeaker(this.name + ' Volume', 'tvSpeakerService');
-    this.tvSpeakerService
-        .setCharacteristic(Characteristic.Active, Characteristic.Active.ACTIVE)
-        .setCharacteristic(Characteristic.VolumeControlType, Characteristic.VolumeControlType.ABSOLUTE);
-    this.tvSpeakerService
-        .getCharacteristic(Characteristic.VolumeSelector)
-        .on('set', this.setVolumeRelative.bind(this));
-    this.tvSpeakerService
-        .getCharacteristic(Characteristic.Mute)
-        .on('get', this.getMuteState.bind(this))
-        .on('set', this.setMuteState.bind(this));
-    this.tvSpeakerService
-        .addCharacteristic(Characteristic.Volume)
-        .on('get', this.getVolumeState.bind(this))
-		.on('set', this.setVolumeState.bind(this));
-
-    this.tvService.addLinkedService(this.tvSpeakerService);
-    this.enabledServices.push(this.tvSpeakerService);
-
-};
-
-OnkyoAccessory.prototype.prepareVolumeDimmer = function(service) {
-	this.dimmer = new Service.Lightbulb(this.name + ' Volume', 'dimmer');
-	this.dimmer
-		.getCharacteristic(Characteristic.On)
-		// Inverted logic taken from https://github.com/langovoi/homebridge-upnp
-		.on('get', (callback) => {
-			this.getMuteState((err, value) => {
-				if (err) {
-					callback(err);
-					return;
-				}
-
-				callback(null, !value);
-			})
-		})
-		.on('set', (value, callback) => this.setMuteState(!value, callback));
-	this.dimmer
-		.addCharacteristic(Characteristic.Brightness)
-		.on('get', this.getVolumeState.bind(this))
-		.on('set', this.setVolumeState.bind(this));
-	
-	service.addLinkedService(this.dimmer);
-	this.enabledServices.push(this.dimmer);
-
+	getServices() {
+		return this.enabledServices;
+	}
 }

--- a/index.js
+++ b/index.js
@@ -27,9 +27,8 @@ function OnkyoPlatform (log, config, api) {
 
 OnkyoPlatform.prototype.accessories = function(callback) {
 	var self = this;
-	this.log.info("Config: %s", this.config);
 	this.numberReceivers = this.receivers.length;
-	this.log.info("Creating %s receivers...", this.numberReceivers);
+	this.log.debug("Creating %s receivers...", this.numberReceivers);
 
 	this.receivers.forEach(function(receiver) {
 		var accessory = new OnkyoAccessory(self, receiver);
@@ -39,9 +38,6 @@ OnkyoPlatform.prototype.accessories = function(callback) {
 	callback(accessories);
 }
 
-// function OnkyoAccessory (platform, receiver) {
-// 	this.init.call(this, platform, receiver)
-// }
 
 function OnkyoAccessory (platform, receiver)
 {	
@@ -54,7 +50,6 @@ function OnkyoAccessory (platform, receiver)
 	this.enabledServices = [];
 
 	config = receiver;
-	this.log.info("Receiver: %j", config);
 	this.name = config["name"];
 	this.ip_address	= config["ip_address"];
 	this.model = config["model"];
@@ -63,8 +58,6 @@ function OnkyoAccessory (platform, receiver)
 	this.volume_dimmer = config["volume_dimmer"] || false;
 	this.switch_service = config["switch_service"] || false;
 
-	// var uuid = UUIDGen.generate(this.name);
-	// this.accessory = new Accessory(this.name, uuid);
 
 	this.cmdMap = new Array();
 	this.cmdMap["main"] = new Array();
@@ -103,15 +96,15 @@ function OnkyoAccessory (platform, receiver)
 	this.avrManufacturer = "Onkyo";
 	this.avrSerial = this.ip_address;
 
-//	this.eiscp.discover(function(err,result){
-//		if(err) {
-//			that.log.debug("Onkyo - ERROR - No RX found. Result: %s", result);
-//        } else {
-//			that.log.debug("Onkyo - Found these receivers on the local network. Connecting to first...");
-//			that.log.debug(result);
-//			that.avrSerial = result[0].mac;
-//        }
-//	});
+	// this.eiscp.discover(function(err,result){
+	// 	if(err) {
+	// 		that.log.debug("Onkyo - ERROR - No RX found. Result: %s", result);
+    //    } else {
+	// 		that.log.debug("Onkyo - Found these receivers on the local network. Connecting to first...");
+	// 		that.log.debug(result);
+	// 		that.avrSerial = result[0].mac;
+    //    }
+	// });
 
 	this.switchHandling = "check";
 	if (this.interval > 10 && this.interval < 100000) {
@@ -224,7 +217,7 @@ OnkyoAccessory.prototype = {
 
 eventDebug: function( response)
 {
-	//this.log.info( "eventDebug: %s", response);
+	this.log.debug( "eventDebug: %s", response);
 },
 
 eventError: function( response)
@@ -234,15 +227,14 @@ eventError: function( response)
 
 eventConnect: function( response)
 {
-	this.log.info( "eventConnect: %s", response);
+	this.log.debug( "eventConnect: %s", response);
 	this.reachable = true;
 },
 
 eventSystemPower: function( response)
 {
-	//this.log.info( "eventSystemPower: %s", response);
 	this.state = (response == "on");
-	this.log.info("eventSystemPower - message: %s, new state %s", response, this.state);
+	this.log.debug("eventSystemPower - message: %s, new state %s", response, this.state);
 	//Communicate status
 	if (this.tvService ) {
 		this.tvService.getCharacteristic(Characteristic.Active).setValue(this.state, null, "statuspoll");
@@ -319,7 +311,7 @@ setPowerState: function(powerOn, callback, context) {
 	var that = this;
 //if context is statuspoll, then we need to ensure that we do not set the actual value
 	if (context && context == "statuspoll") {
-		this.log.info( "setPowerState - polling mode, ignore, state: %s", this.state);
+		this.log.debug( "setPowerState - polling mode, ignore, state: %s", this.state);
 		callback(null, this.state);
 	    return;
 	}
@@ -336,7 +328,7 @@ setPowerState: function(powerOn, callback, context) {
 	that.state = powerOn;
 	callback( null, that.state);
     if (powerOn) {
-		this.log.info("setPowerState - actual mode, power state: %s, switching to ON", that.state);
+		this.log.debug("setPowerState - actual mode, power state: %s, switching to ON", that.state);
 		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["power"] + "=on", function(error, response) {
 			//that.log.debug( "PWR ON: %s - %s -- current state: %s", error, response, that.state);
 			if (error) {
@@ -369,7 +361,7 @@ setPowerState: function(powerOn, callback, context) {
 			}
 		}.bind(this) );
 	} else {
-		this.log.info("setPowerState - actual mode, power state: %s, switching to OFF", that.state);
+		this.log.debug("setPowerState - actual mode, power state: %s, switching to OFF", that.state);
 		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["power"] + "=standby", function(error, response) {
 			//that.log.debug( "PWR OFF: %s - %s -- current state: %s", error, response, that.state);
 			if (error) {
@@ -451,7 +443,7 @@ setVolumeState: function(volumeLvl, callback, context) {
 	var that = this;
 //if context is v_statuspoll, then we need to ensure that we do not set the actual value
 	if (context && context == "v_statuspoll") {
-		this.log.info( "setVolumeState - polling mode, ignore, v_state: %s", this.v_state);
+		this.log.debug( "setVolumeState - polling mode, ignore, v_state: %s", this.v_state);
 		callback(null, this.v_state);
 	    return;
 	}
@@ -468,15 +460,15 @@ setVolumeState: function(volumeLvl, callback, context) {
         var volumeMultiplier = this.maxVolume/100;
         var newVolume = volumeMultiplier * volumeLvl;
 		this.v_state = round(newVolume);
-		this.log.info("setVolumeState - actual mode, PERCENT, volume v_state: %s", that.v_state);
+		this.log.debug("setVolumeState - actual mode, PERCENT, volume v_state: %s", that.v_state);
 	} else if (volumeLvl > this.maxVolume) {
 	//Determin if maxVolume threshold breached, if so set to max.
 		that.v_state = this.maxVolume;
-		this.log.info("setVolumeState - VOLUME LEVEL of: %s exceeds maxVolume: %s. Resetting to max.", volumeLvl, this.maxVolume);
+		this.log.debug("setVolumeState - VOLUME LEVEL of: %s exceeds maxVolume: %s. Resetting to max.", volumeLvl, this.maxVolume);
 	} else {
 	// Must be using actual volume number
 		that.v_state = volumeLvl;
-		this.log.info("setVolumeState - actual mode, ACTUAL volume v_state: %s", that.v_state);
+		this.log.debug("setVolumeState - actual mode, ACTUAL volume v_state: %s", that.v_state);
 	}
 
 	//do the callback immediately, to free homekit
@@ -498,7 +490,7 @@ setVolumeRelative: function(volumeDirection, callback, context) {
 	var that = this;
 //if context is v_statuspoll, then we need to ensure that we do not set the actual value
 	if (context && context == "v_statuspoll") {
-		this.log.info( "setVolumeRelative - polling mode, ignore, v_state: %s", this.v_state);
+		this.log.debug( "setVolumeRelative - polling mode, ignore, v_state: %s", this.v_state);
 		callback(null, this.v_state);
 	    return;
 	}
@@ -514,7 +506,7 @@ setVolumeRelative: function(volumeDirection, callback, context) {
 	//have the event later on execute changes
 	callback( null, that.v_state);
 	if (volumeDirection == Characteristic.VolumeSelector.INCREMENT) {
-		this.log.info("setVolumeRelative - VOLUME : level-up")
+		this.log.debug("setVolumeRelative - VOLUME : level-up")
 		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["volume"] + ":" + "level-up", function(error, response) {
 			if (error) {
 				that.v_state = 0;
@@ -522,7 +514,7 @@ setVolumeRelative: function(volumeDirection, callback, context) {
 			}
 		}.bind(this) );
 	} else if (volumeDirection == Characteristic.VolumeSelector.DECREMENT) {
-		this.log.info("setVolumeRelative - VOLUME : level-down")
+		this.log.debug("setVolumeRelative - VOLUME : level-down")
 		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["volume"] + ":" + "level-down", function(error, response) {
 			if (error) {
 				that.v_state = 0;
@@ -570,7 +562,7 @@ setMuteState: function(muteOn, callback, context) {
 	var that = this;
 //if context is m_statuspoll, then we need to ensure that we do not set the actual value
 	if (context && context == "m_statuspoll") {
-		this.log.info( "setMuteState - polling mode, ignore, m_state: %s", this.m_state);
+		this.log.debug( "setMuteState - polling mode, ignore, m_state: %s", this.m_state);
 		callback(null, this.m_state);
 	    return;
 	}
@@ -587,7 +579,7 @@ setMuteState: function(muteOn, callback, context) {
 	that.m_state = muteOn;
 	callback( null, that.m_state);
     if (that.m_state) {
-		this.log.info("setMuteState - actual mode, mute m_state: %s, switching to ON", that.m_state);
+		this.log.debug("setMuteState - actual mode, mute m_state: %s, switching to ON", that.m_state);
 		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["muting"] + "=on", function(error, response) {
 			if (error) {
 				that.m_state = false;
@@ -598,7 +590,7 @@ setMuteState: function(muteOn, callback, context) {
 			}
 		}.bind(this) );
 	} else {
-		this.log.info("setMuteState - actual mode, mute m_state: %s, switching to OFF", that.m_state);
+		this.log.debug("setMuteState - actual mode, mute m_state: %s, switching to OFF", that.m_state);
 		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["muting"] + "=off", function(error, response) {
 			if (error) {
 				that.m_state = false;
@@ -648,7 +640,7 @@ setInputSource: function(source, callback, context) {
 	var that = this;
 //if context is i_statuspoll, then we need to ensure that we do not set the actual value
 	if (context && context == "i_statuspoll") {
-		this.log.info( "setInputState - polling mode, ignore, i_state: %s", this.i_state);
+		this.log.debug( "setInputState - polling mode, ignore, i_state: %s", this.i_state);
 		callback(null, this.i_state);
 	    return;
 	}
@@ -660,7 +652,7 @@ setInputSource: function(source, callback, context) {
 
 	this.setAttempt = this.setAttempt+1;
 	that.i_state = parseInt(source);
-	this.log.info("setInputState - actual mode, ACTUAL input i_state: %s - label: %s", that.i_state, RxInputs.Inputs[that.i_state].label);
+	this.log.debug("setInputState - actual mode, ACTUAL input i_state: %s - label: %s", that.i_state, RxInputs.Inputs[that.i_state].label);
 
 	//do the callback immediately, to free homekit
 	//have the event later on execute changes
@@ -683,7 +675,7 @@ remoteKeyPress: function(button, callback) {
 	callback(null, this.i_state);
 	if (this.buttons[button]) {
 		var press = this.buttons[button]
-		this.log.info("remoteKeyPress - INPUT: pressing key %s", press);
+		this.log.debug("remoteKeyPress - INPUT: pressing key %s", press);
 		this.eiscp.command(this.zone + "." + "setup=" + press, function( error, data) {
 			if (error) {
 				that.i_state = 1;
@@ -747,6 +739,7 @@ getServices: function() {
 	this.enabledServices.push(informationService);
 
 	if (this.switch_service) {
+		this.log.debug("Creating Switch service for receiver %s", this.name)
 		this.switchService = new Service.Switch(this.name);
 
 		this.switchService
@@ -769,10 +762,11 @@ getServices: function() {
 		this.switchService.addCharacteristic(RxTypes.InputLabel);
 		this.enabledServices.push(this.switchService);
 		if (this.volume_dimmer) {
+			this.log.debug("Creating Dimmer service linked to Switch for receiver %s", this.name)
 			this.prepareVolumeDimmer(this.switchService);
 		}
 	} else {
-
+		this.log.debug("Creating TV service for receiver %s", this.name)
 		this.tvService = new Service.Television(this.name);
 
 		this.tvService
@@ -805,6 +799,7 @@ getServices: function() {
 		this.enabledServices.push(this.tvService);
 		this.prepareTvSpeakerService();
 		if (this.volume_dimmer) {
+			this.log.debug("Creating Dimmer service linked to TV for receiver %s", this.name)
 			this.prepareVolumeDimmer(this.tvService);
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ function OnkyoAccessory (platform, receiver)
 			that.state = data;
 			that.log.debug("event - PWR status poller - new state: ", that.state);
 			if (that.tvService ) {
-				that.tvService.getCharacteristic(Characteristic.Active).setValue(that.state, null, "statuspoll");
+				that.tvService.getCharacteristic(Characteristic.Active).updateValue(that.state, null, "statuspoll");
 			}
 		});
 // Audio-Input Polling
@@ -175,7 +175,7 @@ function OnkyoAccessory (platform, receiver)
 			that.i_state = data;
 			that.log.debug("event - INPUT status poller - new i_state: ", that.i_state);
 			if (that.tvService ) {
-				that.tvService.getCharacteristic(Characteristic.ActiveIdentifier).setValue(that.i_state, null, "i_statuspoll");
+				that.tvService.getCharacteristic(Characteristic.ActiveIdentifier).updateValue(that.i_state, null, "i_statuspoll");
 			}
 		});
 // Audio-Muting Polling
@@ -191,7 +191,7 @@ function OnkyoAccessory (platform, receiver)
 			that.m_state = data;
 			that.log.debug("event - MUTE status poller - new m_state: ", that.m_state);
 			if (that.tvService ) {
-				that.tvService.getCharacteristic(Characteristic.Mute).setValue(that.m_state, null, "m_statuspoll");
+				that.tvService.getCharacteristic(Characteristic.Mute).updateValue(that.m_state, null, "m_statuspoll");
 			}
 		});
 // Volume Polling
@@ -207,7 +207,7 @@ function OnkyoAccessory (platform, receiver)
 			that.v_state = data;
 			that.log.debug("event - VOLUME status poller - new v_state: ", that.v_state);
 			if (that.tvService ) {
-				that.tvService.getCharacteristic(Characteristic.Volume).setValue(that.v_state, null, "v_statuspoll");
+				that.tvService.getCharacteristic(Characteristic.Volume).updateValue(that.v_state, null, "v_statuspoll");
 			}
 		});
 	}
@@ -234,10 +234,10 @@ eventConnect: function( response)
 eventSystemPower: function( response)
 {
 	this.state = (response == "on");
-	this.log.debug("eventSystemPower - message: %s, new state %s", response, this.state);
+	this.log.info("eventSystemPower - message: %s, new state %s", response, this.state);
 	//Communicate status
 	if (this.tvService ) {
-		this.tvService.getCharacteristic(Characteristic.Active).setValue(this.state, null, "statuspoll");
+		this.tvService.getCharacteristic(Characteristic.Active).updateValue(this.state, null, "statuspoll");
 	}
 },
 
@@ -247,7 +247,7 @@ eventAudioMuting: function( response)
 	this.log.debug("eventAudioMuting - message: %s, new m_state %s", response, this.m_state);
 	//Communicate status
 	if (this.tvService ) {
-		this.tvService.getCharacteristic(Characteristic.Mute).setValue(this.m_state, null, "m_statuspoll");
+		this.tvService.getCharacteristic(Characteristic.Mute).updateValue(this.m_state, null, "m_statuspoll");
 	}
 },
 
@@ -266,12 +266,12 @@ eventInput: function( response)
 				break;
 			}
 		}
-		this.log.debug("eventInput - message: %s - new i_state: %s - input: %s", response, this.i_state, input);
+		this.log.info("eventInput - message: %s - new i_state: %s - input: %s", response, this.i_state, input);
 
 		//Communicate status
 		if (this.tvService ) {
 			this.tvService.setCharacteristic(RxTypes.InputLabel,input);
-			this.tvService.getCharacteristic(RxTypes.InputSource).setValue(this.i_state, null, "i_statuspoll");
+			this.tvService.getCharacteristic(RxTypes.InputSource).updateValue(this.i_state, null, "i_statuspoll");
 		}
 	} else {
 		// Then invalid Input chosen
@@ -297,7 +297,7 @@ eventVolume: function( response)
 	}
 	//Communicate status
 	if (this.tvService ) {
-		this.tvService.getCharacteristic(Characteristic.Volume).setValue(this.v_state, null, "v_statuspoll");
+		this.tvService.getCharacteristic(Characteristic.Volume).updateValue(this.v_state, null, "v_statuspoll");
 	}
 },
 
@@ -335,7 +335,7 @@ setPowerState: function(powerOn, callback, context) {
 				that.state = false;
 				that.log.error( "setPowerState - PWR ON: ERROR - current state: %s", that.state);
 				if (that.tvService ) {
-					that.tvService.getCharacteristic(Characteristic.Active).setValue(powerOn, null, "statuspoll");
+					that.tvService.getCharacteristic(Characteristic.Active).updateValue(powerOn, null, "statuspoll");
 				}
 			} else {
 				// If the AVR has just been turned on, apply the default volume
@@ -368,7 +368,7 @@ setPowerState: function(powerOn, callback, context) {
 				that.state = false;
 				that.log.error( "setPowerState - PWR OFF: ERROR - current state: %s", that.state);
 				if (that.tvService ) {
-					that.tvService.getCharacteristic(Characteristic.Active).setValue(that.state, null, "statuspoll");
+					that.tvService.getCharacteristic(Characteristic.Active).updateValue(that.state, null, "statuspoll");
 				}
 			}
 		}.bind(this) );
@@ -401,7 +401,7 @@ getPowerState: function(callback, context) {
 			that.state = false;
 			that.log.debug( "getPowerState - PWR QRY: ERROR - current state: %s", that.state);
 			if (that.tvService ) {
-				that.tvService.getCharacteristic(Characteristic.Active).setValue(that.state, null, "statuspoll");
+				that.tvService.getCharacteristic(Characteristic.Active).updateValue(that.state, null, "statuspoll");
 			}
 		}
 	}.bind(this) );
@@ -433,7 +433,7 @@ getVolumeState: function(callback, context) {
 			that.v_state = 0;
 			that.log.debug( "getVolumeState - VOLUME QRY: ERROR - current v_state: %s", that.v_state);
 			if (that.tvService ) {
-				that.tvService.getCharacteristic(Characteristic.Volume).setValue(that.v_state, null, "v_statuspoll");
+				that.tvService.getCharacteristic(Characteristic.Volume).updateValue(that.v_state, null, "v_statuspoll");
 			}
 		}
 	}.bind(this) );
@@ -480,7 +480,7 @@ setVolumeState: function(volumeLvl, callback, context) {
 			that.v_state = 0;
 			that.log.debug( "setVolumeState - VOLUME : ERROR - current v_state: %s", that.v_state);
 			if (that.switchService ) {
-				that.switchService.getCharacteristic(Characteristic.Volume).setValue(that.v_state, null, "v_statuspoll");
+				that.switchService.getCharacteristic(Characteristic.Volume).updateValue(that.v_state, null, "v_statuspoll");
 			}
 		}
 	}.bind(this) );
@@ -552,7 +552,7 @@ getMuteState: function(callback, context) {
 			that.m_state = false;
 			that.log.debug( "getMuteState - MUTE QRY: ERROR - current m_state: %s", that.m_state);
 			if (that.tvService ) {
-				that.tvService.getCharacteristic(Characteristic.Mute).setValue(that.m_state, null, "m_statuspoll");
+				that.tvService.getCharacteristic(Characteristic.Mute).updateValue(that.m_state, null, "m_statuspoll");
 			}
 		}
 	}.bind(this) );
@@ -585,7 +585,7 @@ setMuteState: function(muteOn, callback, context) {
 				that.m_state = false;
 				that.log.error( "setMuteState - MUTE ON: ERROR - current m_state: %s", that.m_state);
 				if (that.tvService ) {
-					that.tvService.getCharacteristic(Characteristic.Mute).setValue(that.m_state, null, "m_statuspoll");
+					that.tvService.getCharacteristic(Characteristic.Mute).updateValue(that.m_state, null, "m_statuspoll");
 				}
 			}
 		}.bind(this) );
@@ -596,7 +596,7 @@ setMuteState: function(muteOn, callback, context) {
 				that.m_state = false;
 				that.log.error( "setMuteState - MUTE OFF: ERROR - current m_state: %s", that.m_state);
 				if (that.tvService ) {
-					that.tvService.getCharacteristic(Characteristic.Mute).setValue(that.m_state, null, "m_statuspoll");
+					that.tvService.getCharacteristic(Characteristic.Mute).updateValue(that.m_state, null, "m_statuspoll");
 				}
 			}
 		}.bind(this) );
@@ -630,7 +630,7 @@ getInputSource: function(callback, context) {
 			that.log.debug( "getInputState - INPUT QRY: ERROR - current i_state: %s", that.i_state);
 			if (that.tvService ) {
 				that.tvService.setCharacteristic(RxTypes.InputLabel,"get error")
-				that.tvService.getCharacteristic(RxTypes.InputSource).setValue(that.i_state, null, "i_statuspoll");
+				that.tvService.getCharacteristic(RxTypes.InputSource).updateValue(that.i_state, null, "i_statuspoll");
 			}
 		}
 	}.bind(this) );
@@ -663,7 +663,7 @@ setInputSource: function(source, callback, context) {
 			that.log.debug( "setInputState - INPUT : ERROR - current i_state:%s - Source:%s", that.i_state, source.toString());
 			if (that.tvService ) {
 				that.tvService.setCharacteristic(RxTypes.InputLabel,"set error")
-				that.tvService.getCharacteristic(RxTypes.InputSource).setValue(that.i_state, null, "i_statuspoll");
+				that.tvService.getCharacteristic(RxTypes.InputSource).updateValue(that.i_state, null, "i_statuspoll");
 			}
 		}
 	}.bind(this) );
@@ -727,8 +727,6 @@ addSources: function(service) {
 },
 
 getServices: function() {
-	var that = this;
-
 	var informationService = new Service.AccessoryInformation();
     informationService
     .setCharacteristic(Characteristic.Manufacturer, this.avrManufacturer)
@@ -782,10 +780,10 @@ getServices: function() {
 			.on('get', this.getPowerState.bind(this))
 			.on('set', this.setPowerState.bind(this));
 
-		this.tvService
-			.getCharacteristic(Characteristic.On)
-			.on('get', this.getPowerState.bind(this))
-			.on('set', this.setPowerState.bind(this));
+		// this.tvService
+		// 	.getCharacteristic(Characteristic.On)
+		// 	.on('get', this.getPowerState.bind(this))
+		// 	.on('set', this.setPowerState.bind(this));
 
 		this.tvService
 			.getCharacteristic(Characteristic.ActiveIdentifier)

--- a/index.js
+++ b/index.js
@@ -667,7 +667,7 @@ class OnkyoAccessory {
 		//if context is i_statuspoll, then we need to request the actual value
 		if (!context || context != "i_statuspoll") {
 			if (this.switchHandling == "poll") {
-				this.log.info("getInputState - polling mode, return i_state: ", this.i_state);
+				this.log.debug("getInputState - polling mode, return i_state: ", this.i_state);
 				callback(null, this.i_state);
 				return;
 			}
@@ -687,7 +687,7 @@ class OnkyoAccessory {
 		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["input"] + "=query", function( error, data) {
 			if (error) {
 				this.i_state = 1;
-				this.log.info( "getInputState - INPUT QRY: ERROR - current i_state: %s", this.i_state);
+				this.log.error( "getInputState - INPUT QRY: ERROR - current i_state: %s", this.i_state);
 				if (this.tvService ) {
 					this.tvService.setCharacteristic(RxTypes.InputLabel,"get error")
 					this.tvService.getCharacteristic(RxTypes.InputSource).updateValue(this.i_state, null, "i_statuspoll");
@@ -704,43 +704,24 @@ class OnkyoAccessory {
 			return;
 		}
 		if (!this.ip_address) {
-			this.log.info("Ignoring request; No ip_address defined.");
+			this.log.error("Ignoring request; No ip_address defined.");
 			callback(new Error("No ip_address defined."));
 			return;
 		}
 	
 		this.setAttempt = this.setAttempt+1;
-		// var label;
-		// var index;
-		// this.configured_inputs.forEach((a, i) => {
-		// 	this.log.info(a['subtype'])
-		// 	if (a['subtype'] == source) {
-		// 		// this.i_state = a['code'];
-		// 		label = a['displayName'];
-		// 		index = i;
-		// 	}
-		// })
-
-		// for (var a in RxInputs.Inputs) {
-		// 	if (a['code'] == source) {
-		// 		this.i_state = a['code'];
-		// 		break;
-		// 	}
-		// }
 
 		this.i_state = source;
 		const label = RxInputs.Inputs[this.i_state - 1].label;
 
-		this.log.info(this.i_state);
 		this.log.info("setInputState - actual mode, ACTUAL input i_state: %s - label: %s", this.i_state, label);
 	
 		//do the callback immediately, to free homekit
 		//have the event later on execute changes
 		callback(null, this.i_state);
-		this.log.info(RxInputs["Inputs"]);
 		this.eiscp.command(this.zone + "." + this.cmdMap[this.zone]["input"] + ":" + label, function(error, response) {
 			if (error) {
-				this.log.info( "setInputState - INPUT : ERROR - current i_state:%s - Source:%s", this.i_state, source.toString());
+				this.log.error( "setInputState - INPUT : ERROR - current i_state:%s - Source:%s", this.i_state, source.toString());
 				if (this.tvService ) {
 					this.tvService.setCharacteristic(RxTypes.InputLabel,"set error")
 					this.tvService.getCharacteristic(RxTypes.InputSource).updateValue(this.i_state, null, "i_statuspoll");
@@ -750,7 +731,6 @@ class OnkyoAccessory {
 	}
 	
 	remoteKeyPress(button, callback) {
-		this.log.info(button);
 		//do the callback immediately, to free homekit
 		//have the event later on execute changes
 		callback(null, button);
@@ -805,20 +785,8 @@ class OnkyoAccessory {
 		return inputs;
 	}
 
-	// setupInputs(television) {
-	// 	const inputs = this.inputs.map((config, index) => {
-	// 	  const hapId = index + 1;
-	// 	  const input = this.setupInput(config.id, config.name, hapId, television);
-
-	// 	  return input;
-	// 	});
-	
-	// 	return inputs;
-	//   }
-
 	setupInput(inputCode, name, hapId, television) {	
 		const input = new Service.InputSource(`${this.name} ${name}`, inputCode);
-		// const hdmiRegexp = /tvinput\.hdmi\d+/m;
 		const inputSourceType = Characteristic.InputSourceType.HDMI
 
 		input
@@ -846,16 +814,8 @@ class OnkyoAccessory {
 			.setCharacteristic(Characteristic.SerialNumber, this.avrSerial)
 			.setCharacteristic(Characteristic.FirmwareRevision, info.version)
 			.setCharacteristic(Characteristic.Name, this.name);
-
-		// informationService
-		// 	.setCharacteristic(Characteristic.Manufacturer, "Onkyo")
-		// 	.setCharacteristic(Characteristic.Model, "TX-NR515")
-		// 	.setCharacteristic(Characteristic.SerialNumber, "abcde12345")
-		// 	.setCharacteristic(Characteristic.FirmwareRevision, "0.0")
-		// 	.setCharacteristic(Characteristic.Name, "Receiver");
 		
 		return informationService;
-		// this.enabledServices.push(informationService);
 	}
 
 	createSwitchService() {
@@ -886,71 +846,6 @@ class OnkyoAccessory {
 			this.createVolumeDimmer(this.switchService);
 		}
 	}
-
-	// createTvService() {
-	// 	this.log.debug("Creating TV service for receiver %s", this.name)
-	// 	const tvService = new Service.Television(this.name);
-
-	// 	this.addSources(tvService)
-
-	// 	tvService
-	// 		.setCharacteristic(Characteristic.ConfiguredName, this.name);
-	// 		// .setProps({
-	// 		// 	perms: [Characteristic.Perms.READ]
-	// 		// });
-		
-	// 	tvService
-	// 		.setCharacteristic(Characteristic.SleepDiscoveryMode, Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE);
-		
-	// 	tvService
-	// 		.getCharacteristic(Characteristic.Active)
-	// 		.on('get', this.getPowerState.bind(this))
-	// 		.on('set', this.setPowerState.bind(this));
-
-	// 	// this.tvService
-	// 	// 	.getCharacteristic(Characteristic.On)
-	// 	// 	.on('get', this.getPowerState.bind(this))
-	// 	// 	.on('set', this.setPowerState.bind(this));
-
-	// 	tvService
-	// 		.getCharacteristic(Characteristic.ActiveIdentifier)
-	// 		.on('set', this.setInputSource.bind(this))
-	// 		.on('get', this.getInputSource.bind(this));
-		
-	// 	tvService
-	// 		.getCharacteristic(Characteristic.RemoteKey)
-	// 		.on('set', this.remoteKeyPress.bind(this));
-			
-	// 	// this.enabledServices.push(this.tvService);
-	// 	// if (this.volume_dimmer) {
-	// 	// 	this.log.debug("Creating Dimmer service linked to TV for receiver %s", this.name)
-	// 	// 	this.createVolumeDimmer(this.tvService);
-	// 	// }
-	// 	return tvService;
-	// }
-	
-	// createTvSpeakerService(television) {
-	// 	var tvSpeakerService = new Service.TelevisionSpeaker(this.name + ' Volume');
-	// 	tvSpeakerService
-	// 		.setCharacteristic(Characteristic.Active, Characteristic.Active.ACTIVE)
-	// 		.setCharacteristic(Characteristic.VolumeControlType, Characteristic.VolumeControlType.ABSOLUTE);
-	// 	tvSpeakerService
-	// 		.getCharacteristic(Characteristic.VolumeSelector)
-	// 		.on('set', this.setVolumeRelative.bind(this));
-	// 	tvSpeakerService
-	// 		.getCharacteristic(Characteristic.Mute)
-	// 		.on('get', this.getMuteState.bind(this))
-	// 		.on('set', this.setMuteState.bind(this));
-	// 	tvSpeakerService
-	// 		.addCharacteristic(Characteristic.Volume)
-	// 		.on('get', this.getVolumeState.bind(this))
-	// 		.on('set', this.setVolumeState.bind(this));
-	
-	// 	this.log.info(tvSpeakerService);
-		
-	// 	television.addLinkedService(this.tvSpeakerService);
-	// 	this.enabledServices.push(this.tvSpeakerService);
-	// }
 	
 	createVolumeDimmer(service) {
 		this.dimmer = new Service.Lightbulb(this.name + ' Volume', 'dimmer');
@@ -977,71 +872,134 @@ class OnkyoAccessory {
 		this.enabledServices.push(this.dimmer);
 	}
 
-}
-
-OnkyoAccessory.prototype.createTvService = function() {
-	this.log.debug("Creating TV service for receiver %s", this.name)
-	const tvService = new Service.Television(this.name);
-
-	tvService
-		.getCharacteristic(Characteristic.ConfiguredName)
-		.setValue(this.name)
-		.setProps({
-			perms: [Characteristic.Perms.READ]
-		});
+	createTvService() {
+		this.log.debug("Creating TV service for receiver %s", this.name)
+		const tvService = new Service.Television(this.name);
 	
-	tvService
-		.setCharacteristic(Characteristic.SleepDiscoveryMode, Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE);
-	
-	tvService
-		.getCharacteristic(Characteristic.Active)
-		.on('get', this.getPowerState.bind(this))
-		.on('set', this.setPowerState.bind(this));
-
-	// this.tvService
-	// 	.getCharacteristic(Characteristic.On)
-	// 	.on('get', this.getPowerState.bind(this))
-	// 	.on('set', this.setPowerState.bind(this));
-
-	tvService
-		.getCharacteristic(Characteristic.ActiveIdentifier)
-		.on('set', this.setInputSource.bind(this))
-		.on('get', this.getInputSource.bind(this));
-	
-	tvService
-		.getCharacteristic(Characteristic.RemoteKey)
-		.on('set', this.remoteKeyPress.bind(this));
+		tvService
+			.getCharacteristic(Characteristic.ConfiguredName)
+			.setValue(this.name)
+			.setProps({
+				perms: [Characteristic.Perms.READ]
+			});
 		
-	// this.enabledServices.push(this.tvService);
-	// if (this.volume_dimmer) {
-	// 	this.log.debug("Creating Dimmer service linked to TV for receiver %s", this.name)
-	// 	this.createVolumeDimmer(this.tvService);
-	// }
-	return tvService;
+		tvService
+			.setCharacteristic(Characteristic.SleepDiscoveryMode, Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE);
+		
+		tvService
+			.getCharacteristic(Characteristic.Active)
+			.on('get', this.getPowerState.bind(this))
+			.on('set', this.setPowerState.bind(this));
+	
+		// this.tvService
+		// 	.getCharacteristic(Characteristic.On)
+		// 	.on('get', this.getPowerState.bind(this))
+		// 	.on('set', this.setPowerState.bind(this));
+	
+		tvService
+			.getCharacteristic(Characteristic.ActiveIdentifier)
+			.on('set', this.setInputSource.bind(this))
+			.on('get', this.getInputSource.bind(this));
+		
+		tvService
+			.getCharacteristic(Characteristic.RemoteKey)
+			.on('set', this.remoteKeyPress.bind(this));
+			
+		// this.enabledServices.push(this.tvService);
+		// if (this.volume_dimmer) {
+		// 	this.log.debug("Creating Dimmer service linked to TV for receiver %s", this.name)
+		// 	this.createVolumeDimmer(this.tvService);
+		// }
+		return tvService;
+	}
+
+	createTvSpeakerService(tvService) {
+
+		this.tvSpeakerService = new Service.TelevisionSpeaker(this.name + ' Volume', 'tvSpeakerService');
+		this.tvSpeakerService
+			.setCharacteristic(Characteristic.Active, Characteristic.Active.ACTIVE)
+			.setCharacteristic(Characteristic.VolumeControlType, Characteristic.VolumeControlType.ABSOLUTE);
+		this.tvSpeakerService
+			.getCharacteristic(Characteristic.VolumeSelector)
+			.on('set', this.setVolumeRelative.bind(this));
+		this.tvSpeakerService
+			.getCharacteristic(Characteristic.Mute)
+			.on('get', this.getMuteState.bind(this))
+			.on('set', this.setMuteState.bind(this));
+		this.tvSpeakerService
+			.addCharacteristic(Characteristic.Volume)
+			.on('get', this.getVolumeState.bind(this))
+			.on('set', this.setVolumeState.bind(this));
+	
+		tvService.addLinkedService(this.tvSpeakerService);
+		this.enabledServices.push(this.tvSpeakerService);
+	}
+
 }
 
-OnkyoAccessory.prototype.createTvSpeakerService = function(tvService) {
+// OnkyoAccessory.prototype.createTvService = function() {
+// 	this.log.debug("Creating TV service for receiver %s", this.name)
+// 	const tvService = new Service.Television(this.name);
 
-    this.tvSpeakerService = new Service.TelevisionSpeaker(this.name + ' Volume', 'tvSpeakerService');
-    this.tvSpeakerService
-        .setCharacteristic(Characteristic.Active, Characteristic.Active.ACTIVE)
-        .setCharacteristic(Characteristic.VolumeControlType, Characteristic.VolumeControlType.ABSOLUTE);
-    this.tvSpeakerService
-        .getCharacteristic(Characteristic.VolumeSelector)
-        .on('set', this.setVolumeRelative.bind(this));
-    this.tvSpeakerService
-        .getCharacteristic(Characteristic.Mute)
-        .on('get', this.getMuteState.bind(this))
-        .on('set', this.setMuteState.bind(this));
-    this.tvSpeakerService
-        .addCharacteristic(Characteristic.Volume)
-        .on('get', this.getVolumeState.bind(this))
-		.on('set', this.setVolumeState.bind(this));
+// 	tvService
+// 		.getCharacteristic(Characteristic.ConfiguredName)
+// 		.setValue(this.name)
+// 		.setProps({
+// 			perms: [Characteristic.Perms.READ]
+// 		});
+	
+// 	tvService
+// 		.setCharacteristic(Characteristic.SleepDiscoveryMode, Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE);
+	
+// 	tvService
+// 		.getCharacteristic(Characteristic.Active)
+// 		.on('get', this.getPowerState.bind(this))
+// 		.on('set', this.setPowerState.bind(this));
 
-    tvService.addLinkedService(this.tvSpeakerService);
-    this.enabledServices.push(this.tvSpeakerService);
+// 	// this.tvService
+// 	// 	.getCharacteristic(Characteristic.On)
+// 	// 	.on('get', this.getPowerState.bind(this))
+// 	// 	.on('set', this.setPowerState.bind(this));
 
-};
+// 	tvService
+// 		.getCharacteristic(Characteristic.ActiveIdentifier)
+// 		.on('set', this.setInputSource.bind(this))
+// 		.on('get', this.getInputSource.bind(this));
+	
+// 	tvService
+// 		.getCharacteristic(Characteristic.RemoteKey)
+// 		.on('set', this.remoteKeyPress.bind(this));
+		
+// 	// this.enabledServices.push(this.tvService);
+// 	// if (this.volume_dimmer) {
+// 	// 	this.log.debug("Creating Dimmer service linked to TV for receiver %s", this.name)
+// 	// 	this.createVolumeDimmer(this.tvService);
+// 	// }
+// 	return tvService;
+// }
+
+// OnkyoAccessory.prototype.createTvSpeakerService = function(tvService) {
+
+//     this.tvSpeakerService = new Service.TelevisionSpeaker(this.name + ' Volume', 'tvSpeakerService');
+//     this.tvSpeakerService
+//         .setCharacteristic(Characteristic.Active, Characteristic.Active.ACTIVE)
+//         .setCharacteristic(Characteristic.VolumeControlType, Characteristic.VolumeControlType.ABSOLUTE);
+//     this.tvSpeakerService
+//         .getCharacteristic(Characteristic.VolumeSelector)
+//         .on('set', this.setVolumeRelative.bind(this));
+//     this.tvSpeakerService
+//         .getCharacteristic(Characteristic.Mute)
+//         .on('get', this.getMuteState.bind(this))
+//         .on('set', this.setMuteState.bind(this));
+//     this.tvSpeakerService
+//         .addCharacteristic(Characteristic.Volume)
+//         .on('get', this.getVolumeState.bind(this))
+// 		.on('set', this.setVolumeState.bind(this));
+
+//     tvService.addLinkedService(this.tvSpeakerService);
+//     this.enabledServices.push(this.tvSpeakerService);
+
+// };
 
 module.exports = (homebridge) =>
 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-onkyo",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "description": "Homebridge plugin for Onkyo Receivers",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-onkyo",
-  "version": "0.8.0",
+  "version": "0.7.0",
   "description": "Homebridge plugin for Onkyo Receivers",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-onkyo",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Homebridge plugin for Onkyo Receivers",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-onkyo",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Homebridge plugin for Onkyo Receivers",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Medium-level refactor. Fixes odd incompatibilities with iOS 13 where somehow inputs were overriding the information service. I don't quite know why the changes are necessary, but the logic was taken from https://github.com/bschlenk/homebridge-roku/tree/develop and works.

Reverted from Platform to Accessory for compatibility sake and easier upgrades. I didn't feel like it got us many improvements with the way I was handling things. Much of the logic is still in the code but commented out so it should be pretty easy to go back to Platform when it makes sense and we'll actually use it better as one.