### PR TITLE
Fix for https://github.com/ToddGreenfield/homebridge-onkyo/issues/82, ignore case for zone variable.

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ class OnkyoAccessory {
 		this.log.debug('IP %s', this.ip_address);
 		this.model = this.config.model;
 		this.log.debug('Model %s', this.model);
-		this.zone = this.config.zone || 'main';
+		this.zone = this.config.zone.toLowerCase() || 'main';
 		this.log.debug('Zone %s', this.zone);
 
 		if (this.config.volume_dimmer === undefined) {

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ class OnkyoPlatform {
 		receivers.forEach(receiver => {
 			if(!this.connections[receiver.ip_address])
 			{
-				platform.log.debug('Creating new connection for ip %s' , receiver.ip_address);
+				platform.log.info('Creating new connection for ip %s' , receiver.ip_address);
 				this.connections[receiver.ip_address] = require('eiscp');
 				this.connections[receiver.ip_address].connect({host:receiver.ip_address, reconnect:true,model:receiver.model})
 
@@ -139,6 +139,7 @@ class OnkyoAccessory {
 		this.switchHandling = 'check';
 		if (this.interval > 10 && this.interval < 100000)
 			this.switchHandling = 'poll';
+
 		if (this.eiscp){
 			this.eiscp.on('debug', this.eventDebug.bind(this));
 			this.eiscp.on('error', this.eventError.bind(this));
@@ -148,10 +149,10 @@ class OnkyoAccessory {
 			this.eiscp.on(this.cmdMap[this.zone].volume, this.eventVolume.bind(this));
 			this.eiscp.on(this.cmdMap[this.zone].muting, this.eventAudioMuting.bind(this));
 			this.eiscp.on(this.cmdMap[this.zone].input, this.eventInput.bind(this));
+		}
 
 			this.setUp();
 
-		}
 	}
 
 	setUp() {
@@ -314,7 +315,7 @@ class OnkyoAccessory {
 	}
 
 	eventConnect(response) {
-		this.log.debug('eventConnect: %s', response);
+		this.log.info('eventConnect: %s', response);
 		this.reachable = true;
 	}
 

--- a/index.js
+++ b/index.js
@@ -139,17 +139,19 @@ class OnkyoAccessory {
 		this.switchHandling = 'check';
 		if (this.interval > 10 && this.interval < 100000)
 			this.switchHandling = 'poll';
+		if (this.eiscp){
+			this.eiscp.on('debug', this.eventDebug.bind(this));
+			this.eiscp.on('error', this.eventError.bind(this));
+			this.eiscp.on('connect', this.eventConnect.bind(this));
+			this.eiscp.on('close', this.eventClose.bind(this));
+			this.eiscp.on(this.cmdMap[this.zone].power, this.eventSystemPower.bind(this));
+			this.eiscp.on(this.cmdMap[this.zone].volume, this.eventVolume.bind(this));
+			this.eiscp.on(this.cmdMap[this.zone].muting, this.eventAudioMuting.bind(this));
+			this.eiscp.on(this.cmdMap[this.zone].input, this.eventInput.bind(this));
 
-		this.eiscp.on('debug', this.eventDebug.bind(this));
-		this.eiscp.on('error', this.eventError.bind(this));
-		this.eiscp.on('connect', this.eventConnect.bind(this));
-		this.eiscp.on('close', this.eventClose.bind(this));
-		this.eiscp.on(this.cmdMap[this.zone].power, this.eventSystemPower.bind(this));
-		this.eiscp.on(this.cmdMap[this.zone].volume, this.eventVolume.bind(this));
-		this.eiscp.on(this.cmdMap[this.zone].muting, this.eventAudioMuting.bind(this));
-		this.eiscp.on(this.cmdMap[this.zone].input, this.eventInput.bind(this));
+			this.setUp();
 
-		this.setUp();
+		}
 	}
 
 	setUp() {

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ class OnkyoPlatform {
 		receivers.forEach(receiver => {
 			if(!connections[receiver.ip_address])
 			{
-				this.log.debug('Creating new connection for ip' = receiver.ip_address);
+				platform.log.debug('Creating new connection for ip %s' , receiver.ip_address);
 				connections[receiver.ip_address] = require('eiscp');
 				connections[receiver.ip_address].connect({host:receiver.ip_address, reconnect:true,model:receiver.model})
 

--- a/index.js
+++ b/index.js
@@ -28,11 +28,11 @@ class OnkyoPlatform {
 		platform.log.debug('Creating %s receivers...', platform.numberReceivers);
 		if (platform.numberReceivers === 0) return;
 		receivers.forEach(receiver => {
-			if(!platform.connections[receiver.ip_address])
+			if(!this.connections[receiver.ip_address])
 			{
 				platform.log.debug('Creating new connection for ip %s' , receiver.ip_address);
-				platform.connections[receiver.ip_address] = require('eiscp');
-				platform.connections[receiver.ip_address].connect({host:receiver.ip_address, reconnect:true,model:receiver.model})
+				this.connections[receiver.ip_address] = require('eiscp');
+				this.connections[receiver.ip_address].connect({host:receiver.ip_address, reconnect:true,model:receiver.model})
 
 			}
 			const accessory = new OnkyoAccessory(platform, receiver);

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ class OnkyoPlatform {
 		receivers.forEach(receiver => {
 			if(!connections[receiver.ip_address])
 			{
-				this.log.debug('Creating new connection for ip' receiver.ip_address);
+				this.log.debug('Creating new connection for ip' = receiver.ip_address);
 				connections[receiver.ip_address] = require('eiscp');
 				connections[receiver.ip_address].connect({host:receiver.ip_address, reconnect:true,model:receiver.model})
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class OnkyoPlatform {
 
 	createAccessories(platform, receivers) {
 		platform.numberReceivers = platform.receivers.length;
-		platform.log.debug('Creating %s receivers...', platform.numberReceivers);
+		platform.log.info('Creating %s receivers...', platform.numberReceivers);
 		if (platform.numberReceivers === 0) return;
 		receivers.forEach(receiver => {
 			if(!this.connections[receiver.ip_address])

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ class OnkyoAccessory {
 		this.log.debug('Debug mode enabled');
 		this.log.info(platform.connections);
 
-		this.eiscp = platform.connections[this.ip_address];
+		this.eiscp = platform.connections[receiver.ip_address];
 		this.setAttempt = 0;
 		this.enabledServices = [];
 

--- a/index.js
+++ b/index.js
@@ -140,16 +140,16 @@ class OnkyoAccessory {
 		if (this.interval > 10 && this.interval < 100000)
 			this.switchHandling = 'poll';
 
-			this.eiscp.on('debug', this.eventDebug.bind(this));
-			this.eiscp.on('error', this.eventError.bind(this));
-			this.eiscp.on('connect', this.eventConnect.bind(this));
-			this.eiscp.on('close', this.eventClose.bind(this));
-			this.eiscp.on(this.cmdMap[this.zone].power, this.eventSystemPower.bind(this));
-			this.eiscp.on(this.cmdMap[this.zone].volume, this.eventVolume.bind(this));
-			this.eiscp.on(this.cmdMap[this.zone].muting, this.eventAudioMuting.bind(this));
-			this.eiscp.on(this.cmdMap[this.zone].input, this.eventInput.bind(this));
+		this.eiscp.on('debug', this.eventDebug.bind(this));
+		this.eiscp.on('error', this.eventError.bind(this));
+		this.eiscp.on('connect', this.eventConnect.bind(this));
+		this.eiscp.on('close', this.eventClose.bind(this));
+		this.eiscp.on(this.cmdMap[this.zone].power, this.eventSystemPower.bind(this));
+		this.eiscp.on(this.cmdMap[this.zone].volume, this.eventVolume.bind(this));
+		this.eiscp.on(this.cmdMap[this.zone].muting, this.eventAudioMuting.bind(this));
+		this.eiscp.on(this.cmdMap[this.zone].input, this.eventInput.bind(this));
 
-			this.setUp();
+		this.setUp();
 
 	}
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ let Characteristic;
 let RxInputs;
 const pollingtoevent = require('polling-to-event');
 const info = require('./package.json');
+const eiscp = require('eiscp');
 
 class OnkyoPlatform {
 	constructor(log, config, api) {
@@ -31,8 +32,7 @@ class OnkyoPlatform {
 			if(!this.connections[receiver.ip_address])
 			{
 				platform.log.info('Creating new connection for ip %s' , receiver.ip_address);
-				this.connections[receiver.ip_address] = require('eiscp');
-				this.connections[receiver.ip_address].connect({host:receiver.ip_address, reconnect:true,model:receiver.model})
+				this.connections[receiver.ip_address] = eiscp.connect({host:receiver.ip_address, reconnect:true,model:receiver.model});
 
 			}
 			const accessory = new OnkyoAccessory(platform, receiver);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ let Characteristic;
 let RxInputs;
 const pollingtoevent = require('polling-to-event');
 const info = require('./package.json');
-const eiscp = require('eiscp');
 
 class OnkyoPlatform {
 	constructor(log, config, api) {
@@ -26,13 +25,14 @@ class OnkyoPlatform {
 
 	createAccessories(platform, receivers) {
 		platform.numberReceivers = platform.receivers.length;
-		platform.log.info('Creating %s receivers...', platform.numberReceivers);
+		platform.log.debug('Creating %s receivers...', platform.numberReceivers);
 		if (platform.numberReceivers === 0) return;
 		receivers.forEach(receiver => {
-			if(!this.connections[receiver.ip_address])
+			if(!platform.connections[receiver.ip_address])
 			{
-				platform.log.info('Creating new connection for ip %s' , receiver.ip_address);
-				this.connections[receiver.ip_address] = eiscp.connect({host:receiver.ip_address, reconnect:true,model:receiver.model});
+				platform.log.debug('Creating new connection for ip %s' , receiver.ip_address);
+				platform.connections[receiver.ip_address] = require('eiscp');
+				platform.connections[receiver.ip_address].connect({host:receiver.ip_address, reconnect:true,model:receiver.model})
 
 			}
 			const accessory = new OnkyoAccessory(platform, receiver);
@@ -150,7 +150,6 @@ class OnkyoAccessory {
 			this.eiscp.on(this.cmdMap[this.zone].muting, this.eventAudioMuting.bind(this));
 			this.eiscp.on(this.cmdMap[this.zone].input, this.eventInput.bind(this));
 		}
-
 			this.setUp();
 
 	}
@@ -315,7 +314,7 @@ class OnkyoAccessory {
 	}
 
 	eventConnect(response) {
-		this.log.info('eventConnect: %s', response);
+		this.log.debug('eventConnect: %s', response);
 		this.reachable = true;
 	}
 

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ class OnkyoPlatform {
 			const accessory = new OnkyoAccessory(platform, receiver);
 			platform.receiverAccessories.push(accessory);
 			});
+		this.log.info(platform.connections);
 	}
 
 	accessories(callback) {
@@ -56,6 +57,7 @@ class OnkyoAccessory {
 		this.log.info('**************************************************************');
 		this.log.info('start success...');
 		this.log.debug('Debug mode enabled');
+		this.log.info(platform.connections);
 
 		this.eiscp = platform.connections[this.ip_address];
 		this.setAttempt = 0;
@@ -148,7 +150,7 @@ class OnkyoAccessory {
 			this.eiscp.on(this.cmdMap[this.zone].volume, this.eventVolume.bind(this));
 			this.eiscp.on(this.cmdMap[this.zone].muting, this.eventAudioMuting.bind(this));
 			this.eiscp.on(this.cmdMap[this.zone].input, this.eventInput.bind(this));
-			
+
 			this.setUp();
 
 	}

--- a/index.js
+++ b/index.js
@@ -38,7 +38,6 @@ class OnkyoPlatform {
 			const accessory = new OnkyoAccessory(platform, receiver);
 			platform.receiverAccessories.push(accessory);
 			});
-		this.log.info(platform.connections);
 	}
 
 	accessories(callback) {
@@ -57,7 +56,6 @@ class OnkyoAccessory {
 		this.log.info('**************************************************************');
 		this.log.info('start success...');
 		this.log.debug('Debug mode enabled');
-		this.log.info(platform.connections);
 
 		this.eiscp = platform.connections[receiver.ip_address];
 		this.setAttempt = 0;

--- a/index.js
+++ b/index.js
@@ -140,7 +140,6 @@ class OnkyoAccessory {
 		if (this.interval > 10 && this.interval < 100000)
 			this.switchHandling = 'poll';
 
-		if (this.eiscp){
 			this.eiscp.on('debug', this.eventDebug.bind(this));
 			this.eiscp.on('error', this.eventError.bind(this));
 			this.eiscp.on('connect', this.eventConnect.bind(this));
@@ -149,7 +148,7 @@ class OnkyoAccessory {
 			this.eiscp.on(this.cmdMap[this.zone].volume, this.eventVolume.bind(this));
 			this.eiscp.on(this.cmdMap[this.zone].muting, this.eventAudioMuting.bind(this));
 			this.eiscp.on(this.cmdMap[this.zone].input, this.eventInput.bind(this));
-		}
+			
 			this.setUp();
 
 	}

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ class OnkyoPlatform {
 		this.log = log;
 		this.receivers = this.config.receivers;
 		this.receiverAccessories = [];
+		this.connections = [];
 
 		if (this.receivers === undefined) {
 			this.log.error('ERROR: your configuration is incorrect. Configuration changed with version 0.7.x');
@@ -27,6 +28,13 @@ class OnkyoPlatform {
 		platform.log.debug('Creating %s receivers...', platform.numberReceivers);
 		if (platform.numberReceivers === 0) return;
 		receivers.forEach(receiver => {
+			if(!connections[receiver.ip_address])
+			{
+				this.log.debug('Creating new connection for ip' receiver.ip_address);
+				connections[receiver.ip_address] = require('eiscp');
+				connections[receiver.ip_address].connect({host:receiver.ip_address, reconnect:true,model:receiver.model})
+
+			}
 			const accessory = new OnkyoAccessory(platform, receiver);
 			platform.receiverAccessories.push(accessory);
 			});
@@ -49,7 +57,7 @@ class OnkyoAccessory {
 		this.log.info('start success...');
 		this.log.debug('Debug mode enabled');
 
-		this.eiscp = require('eiscp');
+		this.eiscp = platform.connections[this.ip_address];
 		this.setAttempt = 0;
 		this.enabledServices = [];
 
@@ -140,10 +148,6 @@ class OnkyoAccessory {
 		this.eiscp.on(this.cmdMap[this.zone].volume, this.eventVolume.bind(this));
 		this.eiscp.on(this.cmdMap[this.zone].muting, this.eventAudioMuting.bind(this));
 		this.eiscp.on(this.cmdMap[this.zone].input, this.eventInput.bind(this));
-
-		this.eiscp.connect(
-			{host: this.ip_address, reconnect: true, model: this.model}
-		);
 
 		this.setUp();
 	}

--- a/index.js
+++ b/index.js
@@ -31,9 +31,16 @@ class OnkyoPlatform {
 			if(!this.connections[receiver.ip_address])
 			{
 				platform.log.debug('Creating new connection for ip %s' , receiver.ip_address);
-				this.connections[receiver.ip_address] = require('eiscp');
-				this.connections[receiver.ip_address].connect({host:receiver.ip_address, reconnect:true,model:receiver.model})
-
+				var eiscp = this.connections[receiver.ip_address] = require('eiscp');	
+				eiscp.connect({host:receiver.ip_address, reconnect:true,model:receiver.model})
+				eiscp.on('debug', this.eventDebug.bind(this));
+				eiscp.on('error', this.eventError.bind(this));
+				eiscp.on('connect', this.eventConnect.bind(this));
+				eiscp.on('close', this.eventClose.bind(this));
+				eiscp.on(this.cmdMap[this.zone].power, this.eventSystemPower.bind(this));
+				eiscp.on(this.cmdMap[this.zone].volume, this.eventVolume.bind(this));
+				eiscp.on(this.cmdMap[this.zone].muting, this.eventAudioMuting.bind(this));
+				eiscp.on(this.cmdMap[this.zone].input, this.eventInput.bind(this));
 			}
 			const accessory = new OnkyoAccessory(platform, receiver);
 			platform.receiverAccessories.push(accessory);
@@ -139,15 +146,6 @@ class OnkyoAccessory {
 		this.switchHandling = 'check';
 		if (this.interval > 10 && this.interval < 100000)
 			this.switchHandling = 'poll';
-
-		this.eiscp.on('debug', this.eventDebug.bind(this));
-		this.eiscp.on('error', this.eventError.bind(this));
-		this.eiscp.on('connect', this.eventConnect.bind(this));
-		this.eiscp.on('close', this.eventClose.bind(this));
-		this.eiscp.on(this.cmdMap[this.zone].power, this.eventSystemPower.bind(this));
-		this.eiscp.on(this.cmdMap[this.zone].volume, this.eventVolume.bind(this));
-		this.eiscp.on(this.cmdMap[this.zone].muting, this.eventAudioMuting.bind(this));
-		this.eiscp.on(this.cmdMap[this.zone].input, this.eventInput.bind(this));
 
 		this.setUp();
 	}

--- a/index.js
+++ b/index.js
@@ -31,16 +31,9 @@ class OnkyoPlatform {
 			if(!this.connections[receiver.ip_address])
 			{
 				platform.log.debug('Creating new connection for ip %s' , receiver.ip_address);
-				var eiscp = this.connections[receiver.ip_address] = require('eiscp');	
-				eiscp.connect({host:receiver.ip_address, reconnect:true,model:receiver.model})
-				eiscp.on('debug', this.eventDebug.bind(this));
-				eiscp.on('error', this.eventError.bind(this));
-				eiscp.on('connect', this.eventConnect.bind(this));
-				eiscp.on('close', this.eventClose.bind(this));
-				eiscp.on(this.cmdMap[this.zone].power, this.eventSystemPower.bind(this));
-				eiscp.on(this.cmdMap[this.zone].volume, this.eventVolume.bind(this));
-				eiscp.on(this.cmdMap[this.zone].muting, this.eventAudioMuting.bind(this));
-				eiscp.on(this.cmdMap[this.zone].input, this.eventInput.bind(this));
+				this.connections[receiver.ip_address] = require('eiscp');
+				this.connections[receiver.ip_address].connect({host:receiver.ip_address, reconnect:true,model:receiver.model})
+
 			}
 			const accessory = new OnkyoAccessory(platform, receiver);
 			platform.receiverAccessories.push(accessory);
@@ -146,6 +139,15 @@ class OnkyoAccessory {
 		this.switchHandling = 'check';
 		if (this.interval > 10 && this.interval < 100000)
 			this.switchHandling = 'poll';
+
+		this.eiscp.on('debug', this.eventDebug.bind(this));
+		this.eiscp.on('error', this.eventError.bind(this));
+		this.eiscp.on('connect', this.eventConnect.bind(this));
+		this.eiscp.on('close', this.eventClose.bind(this));
+		this.eiscp.on(this.cmdMap[this.zone].power, this.eventSystemPower.bind(this));
+		this.eiscp.on(this.cmdMap[this.zone].volume, this.eventVolume.bind(this));
+		this.eiscp.on(this.cmdMap[this.zone].muting, this.eventAudioMuting.bind(this));
+		this.eiscp.on(this.cmdMap[this.zone].input, this.eventInput.bind(this));
 
 		this.setUp();
 	}

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ class OnkyoPlatform {
 		this.log = log;
 		this.receivers = this.config.receivers;
 		this.receiverAccessories = [];
-		this.connections = [];
+		this.connections = {};
 
 		if (this.receivers === undefined) {
 			this.log.error('ERROR: your configuration is incorrect. Configuration changed with version 0.7.x');

--- a/index.js
+++ b/index.js
@@ -28,11 +28,11 @@ class OnkyoPlatform {
 		platform.log.debug('Creating %s receivers...', platform.numberReceivers);
 		if (platform.numberReceivers === 0) return;
 		receivers.forEach(receiver => {
-			if(!connections[receiver.ip_address])
+			if(!this.connections[receiver.ip_address])
 			{
 				platform.log.debug('Creating new connection for ip %s' , receiver.ip_address);
-				connections[receiver.ip_address] = require('eiscp');
-				connections[receiver.ip_address].connect({host:receiver.ip_address, reconnect:true,model:receiver.model})
+				this.connections[receiver.ip_address] = require('eiscp');
+				this.connections[receiver.ip_address].connect({host:receiver.ip_address, reconnect:true,model:receiver.model})
 
 			}
 			const accessory = new OnkyoAccessory(platform, receiver);


### PR DESCRIPTION
Most of the change is outlined in the issue this resolves by creating a dictionary for the eiscp connection, then reusing it for zones that have the same IP address. 

The only other thing I did in here is line 71, which changes the zone variable to all lowercase, eliminating the possibility that it can be wrong due to case issues.
